### PR TITLE
Export non-unicode `deligneproduct`

### DIFF
--- a/src/TensorKit.jl
+++ b/src/TensorKit.jl
@@ -39,7 +39,7 @@ export infimum, supremum, isisomorphic, ismonomorphic, isepimorphic
 
 # methods for sectors and properties thereof
 export sectortype, sectors, hassector, Nsymbol, Fsymbol, Rsymbol, Bsymbol,
-       frobeniusschur, twist, otimes, sectorscalartype
+       frobeniusschur, twist, otimes, sectorscalartype, deligneproduct
 export fusiontrees, braid, permute, transpose
 export ZNSpace, SU2Irrep, U1Irrep, CU1Irrep
 # other fusion tree manipulations, should not be exported:


### PR DESCRIPTION
Noticed this was missing from the things that are re-exported from TensorKitSectors.