### PR TITLE
[WIP] cuTENSOR blocksparse implementation

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -31,6 +31,7 @@ EnzymeTestUtils = "12d8515a-0907-448a-8884-5fe00fdf1c5a"
 FiniteDifferences = "26cc04aa-876d-5657-8c51-4c34ba976000"
 GPUArrays = "0c68f7d7-f131-5f86-a1c3-88cf8149b2d7"
 Mooncake = "da2b9cff-9c12-43a0-ae48-6db2b0edb7d6"
+cuTENSOR = "011b41b2-24ef-40a8-b3eb-fa098493e9e1"
 
 [extensions]
 TensorKitAMDGPUExt = "AMDGPU"
@@ -41,6 +42,7 @@ TensorKitEnzymeTestUtilsExt = "EnzymeTestUtils"
 TensorKitFiniteDifferencesExt = "FiniteDifferences"
 TensorKitGPUArraysExt = "GPUArrays"
 TensorKitMooncakeExt = "Mooncake"
+TensorKitcuTENSORExt = ["CUDA", "cuTENSOR"]
 
 [compat]
 AMDGPU = "2"
@@ -65,4 +67,5 @@ TensorKitSectors = "0.3.7"
 TensorOperations = "5.5.2, 5.6"
 TupleTools = "1.5"
 VectorInterface = "0.6"
+cuTENSOR = "6.2"
 julia = "1.10"

--- a/docs/make.jl
+++ b/docs/make.jl
@@ -33,6 +33,7 @@ pages = [
             "man/indexmanipulations.md",
             "man/factorizations.md",
             "man/contractions.md",
+            "man/backends.md",
         ],
     ],
     "Library" => [

--- a/docs/src/Changelog.md
+++ b/docs/src/Changelog.md
@@ -22,13 +22,24 @@ When releasing a new version, move the "Unreleased" changes to a new version sec
 
 ### Added
 
+- `CuTENSORBlockSparse`, an opt-in backend that carries out a contraction of CUDA-backed tensors with abelian symmetry, fermionic ones included, as a single cuTENSOR block-sparse contraction, without any fusion tree transformation or permutation. Selected with `@tensor backend = CuTENSORBlockSparse()`; unsupported contractions fall back to the default path. Requires `CUDA.jl` and `cuTENSOR.jl`.
+- `plan_contract`, to hoist a reusable block-sparse contraction plan out of a hot loop. Plans are also cached automatically.
+- `blocksparse_compatible`, a trait for the sector types whose raw block data may be contracted directly, possibly up to a per-block scalar. This holds for the irreps of abelian groups, for `FermionParity`, and for products thereof — so `FermionNumber` qualifies but `FermionSpin` does not. Note that `FusionStyle(I) === UniqueFusion()` is *not* sufficient: `ZNElement` has anyonic R-symbols, which are genuine phases rather than signs, and is deliberately excluded.
+- `TensorKit.blocksparse_contract_signs`, which is what makes the fermionic case work. A raw block-wise contraction differs from the categorical one by a sign per fusion tree pair, contributed both by the permutations the default path performs and by the twist it inserts for a dual contracted leg. The correction is derived in factorized form, as one scalar per block of each of the three tensors, and applied by scaling blocks. It is precomputed with the contraction plan, for all four conjugation combinations, so it costs nothing per call beyond the scaling itself. That scaling costs one temporary per operand whose correction is non-trivial; a contraction whose output already has the codomain/domain partition the contraction produces naturally needs no correction of the result.
+- A new manual page documenting backends, plan reuse and block schedulers.
+
 ### Changed
+
+- `TensorOperations.tensorcontract!` for `AbstractTensorMap` now delegates to the internal `TensorKit._tensorcontract!`, which is the designated hook for backends that implement a contraction by a different route than the default fusion-tree/BLAS path.
 
 ### Deprecated
 
 ### Removed
 
 ### Fixed
+
+- `@planar` and `@plansor` silently ignored the `backend =` keyword: the backend was inserted with `TensorOperations.insertbackend`, which only matches calls into `TensorOperations`, whereas the planar operations had already been rewritten to `TensorKit.planaradd!`/`planartrace!`/`planarcontract!`.
+- `benchmark/benchmarks.jl` threw on any `--modules=` argument, and could not accept a comma-separated list.
 
 ### Performance
 

--- a/docs/src/lib/tensors.md
+++ b/docs/src/lib/tensors.md
@@ -194,6 +194,25 @@ contract!
 ⊗(::AbstractTensorMap, ::AbstractTensorMap)
 ```
 
+## Backends and caches
+
+Backends select how an operation is carried out; see [Backends](@ref) for the discussion.
+
+```@docs
+CuTENSORBlockSparse
+blocksparse_compatible
+plan_contract
+TensorKit.blocksparsestructure
+TensorKit.BlockSparseStructure
+TensorKit.blocksparse_contract_signs
+TensorKit.BlockSparseSigns
+TensorKit.BlockSparseUnsupported
+TensorKit.blockscheduler
+TensorKit.with_blockscheduler
+empty_globalcaches!
+TensorKit.global_cache_info
+```
+
 ## `TensorMap` factorizations
 
 The factorization methods are powered by [MatrixAlgebraKit.jl](https://github.com/QuantumKitHub/MatrixAlgebraKit.jl) and all follow the same strategy.

--- a/docs/src/man/backends.md
+++ b/docs/src/man/backends.md
@@ -1,0 +1,103 @@
+# Backends
+
+The `@tensor` and `@planar` macros, as well as the underlying
+[`TensorOperations.tensorcontract!`](@extref) family, accept a `backend =` keyword that selects
+*how* an operation is carried out, leaving *what* it computes unchanged.
+The available backends come from [TensorOperations](https://quantumkithub.github.io/TensorOperations.jl/stable/), which by default
+picks one automatically based on the storage type of the individual blocks — for CPU tensors a
+strided/BLAS backend, for CUDA tensors the dense cuTENSOR backend.
+
+TensorKit additionally provides one backend of its own, which changes the contraction strategy
+at the level of the whole symmetric tensor rather than block by block.
+
+## Block-sparse contractions with cuTENSOR
+
+By default, a symmetric tensor contraction is carried out by first permuting the operands into
+matrix form — which requires fusion tree transformations and temporary tensors — and then
+performing one matrix multiplication per coupled sector.
+For a tensor with many small sectors on the GPU, this is dominated by the cost of launching a
+large number of small kernels.
+
+For abelian symmetries, fermionic ones included, there is a more direct route.
+The way TensorKit stores such a tensor — one dense block per tuple of uncoupled sectors, laid
+out as strided views into a single flat vector — is precisely the *block-sparse* data model of
+cuTENSOR's block-sparse contraction API.
+The index tuples then only determine cuTENSOR mode labels, so the contraction becomes a single
+kernel launch with no permutations and no temporaries:
+
+```julia
+using CUDA, cuTENSOR
+
+V = Vect[U1Irrep](-1 => 32, 0 => 64, 1 => 32)
+A = CuTensorMap(randn(ComplexF64, V ⊗ V ← V))
+B = CuTensorMap(randn(ComplexF64, V ← V ⊗ V))
+
+@tensor backend = CuTENSORBlockSparse() C[a, b, d, e] := A[a, b, c] * B[c, d, e]
+```
+
+This backend is opt-in. cuTENSOR's block-sparse functionality is documented by NVIDIA as a
+*public beta*, with a restricted feature set and no guarantee of API stability between
+releases, so it is never selected automatically. Whether it is faster than one dense
+matrix multiplication per coupled sector depends on how the total dimension is spread over
+sectors.
+
+Fermionic symmetries are supported too. There a raw block-wise contraction is *not* the
+categorical one: the permutations the default path performs, and the twist it inserts for a dual
+contracted leg, each contribute a factor per fusion tree — for fermion parity, a sign. Since
+those factors are scalars, the discrepancy is one scalar per block, and can be corrected by
+scaling blocks rather than by transforming fusion trees. The cost is one temporary per operand
+whose correction is non-trivial; an output that already has the codomain/domain *partition* the
+contraction produces naturally needs no correction of the result at all. Note that a natural
+index *order* is not enough — moving a leg between codomain and domain bends it, and for a
+fermionic sector bending is not free, so `pAB = ((1,2,3,4), ())` does carry a correction even
+though it permutes nothing.
+
+Contractions the backend cannot express fall back to the default path silently, which keeps it
+usable inside a `@tensor` network that mixes supported and unsupported operations. Pass
+`strict = true` to turn those fallbacks into errors instead, and consult
+[`blocksparse_compatible`](@ref) for which symmetries qualify.
+
+```@docs; canonical=false
+CuTENSORBlockSparse
+blocksparse_compatible
+TensorKit.blocksparse_contract_signs
+```
+
+### Reusing plans
+
+Everything cuTENSOR needs to know about a block-sparse contraction — the sparsity pattern, the
+block strides, and the kernel chosen by its heuristic — is a function of the spaces, the index
+tuples and the scalar type alone; the block pointers are supplied only at execution time.
+Plans are therefore reusable, and are cached automatically, so a repeated contraction over
+tensors with the same spaces pays for plan construction only once.
+
+For an inner loop where even the cache lookup is unwanted — an MPS sweep at fixed bond
+dimension, say — a plan can be hoisted out explicitly. Since a plan *is* a fully specialized
+backend, it is passed the same way:
+
+```julia
+plan = plan_contract(C, A, ((1, 2), (3,)), B, ((1,), (2, 3)), ((1, 2), (3, 4)))
+for i in 1:nsweeps
+    @tensor backend = plan C[a, b, d, e] = A[a, b, c] * B[c, d, e]
+end
+```
+
+```@docs; canonical=false
+plan_contract
+```
+
+Plan lifetime can also be scoped without changing call sites, by handing the backend a private
+cache via `CuTENSORBlockSparse(; plans = ...)`. The global cache is registered with TensorKit's
+cache registry, so [`empty_globalcaches!`](@ref) releases plans along with everything else —
+which is worth doing around a `CUDA.device_reset!`, since a plan is only valid on the device
+it was created for.
+
+## Block schedulers
+
+Independently of the backend, the loop over the blocks of a symmetric tensor can be
+parallelized over threads:
+
+```@docs; canonical=false
+TensorKit.blockscheduler
+TensorKit.with_blockscheduler
+```

--- a/docs/src/man/tensors.md
+++ b/docs/src/man/tensors.md
@@ -177,7 +177,7 @@ Indeed, the empty product space is the unit object of the monoidal category, equ
 
 The matrices created by `f` are the matrices ``B_c`` discussed above, i.e. those returned by `block(t, c)`.
 Only numerical matrices of type `DenseMatrix` are accepted, which in practice just means Julia's intrinsic `Matrix{T}` for some `T <: Number`.
-Ongoing work extends this to support for `CuMatrix` from [CuArrays.jl](https://github.com/JuliaGPU/CuArrays.jl) to harness GPU computing power, and future work might include distributed arrays.
+GPU storage is supported by loading [CUDA.jl](https://github.com/JuliaGPU/CUDA.jl) or [AMDGPU.jl](https://github.com/JuliaGPU/AMDGPU.jl), which makes the corresponding device array types available as tensor storage; see also [Backends](@ref). Future work might include distributed arrays.
 
 Support for static or sparse data is currently unavailable, and if it would be implemented, it would likely lead to new subtypes of `AbstractTensorMap` which are distinct from `TensorMap`.
 Future implementations of e.g. `SparseTensorMap` or `StaticTensorMap` could be useful.

--- a/ext/TensorKitcuTENSORExt/TensorKitcuTENSORExt.jl
+++ b/ext/TensorKitcuTENSORExt/TensorKitcuTENSORExt.jl
@@ -1,0 +1,51 @@
+module TensorKitcuTENSORExt
+
+using CUDA
+using CUDA: CuPtr, with_workspace
+using cuTENSOR: cuTENSOR
+
+using LRUCache: LRU
+
+using TensorKit
+using TensorKit: BlockSparseSigns, BlockSparseStructure, BlockSparseUnsupported,
+    CuTENSORBlockSparse, HomSpace, Index2Tuple,
+    blocksparse_compatible, blocksparse_contract_signs,
+    blocksparsestructure, _scale_subblocks!,
+    nblocks, nmodes,
+    GLOBAL_CACHES, _generic_tensorcontract!
+import TensorKit: _tensorcontract!, plan_contract
+
+using TensorOperations: TensorOperations as TO
+
+"""
+    CuTensorMapAny{T, S, N₁, N₂}
+
+Any `TensorMap` whose flat storage lives in CUDA device memory. Dispatching on the concrete
+storage type makes the block-sparse `_tensorcontract!` method unambiguously more specific
+than the generic one, and lets every other tensor type fall through to the default path.
+"""
+const CuTensorMapAny{T, S, N₁, N₂} =
+    TensorMap{T, S, N₁, N₂, <:CUDA.CuVector{T, CUDA.DeviceMemory}}
+
+"""
+The scalar types cuTENSOR's block-sparse backend supports. All of A, B, C, D, α, β and the
+compute type must agree.
+"""
+const BLOCKSPARSE_TYPES = Union{Float32, Float64, ComplexF32, ComplexF64}
+
+"Maximum number of modes the block-sparse backend accepts: 8 up to cuTENSOR 2.5, 32 from 2.7."
+const MAX_BLOCKSPARSE_MODES = 8
+
+include("descriptors.jl")
+include("plan.jl")
+include("contract.jl")
+
+function __init__()
+    # register with TensorKit's cache registry, so `empty_globalcaches!` covers the plan cache
+    if !any(((name, _),) -> name === :BLOCKSPARSE_PLAN_CACHE, GLOBAL_CACHES)
+        push!(GLOBAL_CACHES, :BLOCKSPARSE_PLAN_CACHE => BLOCKSPARSE_PLAN_CACHE)
+    end
+    return nothing
+end
+
+end

--- a/ext/TensorKitcuTENSORExt/contract.jl
+++ b/ext/TensorKitcuTENSORExt/contract.jl
@@ -1,0 +1,213 @@
+# Applicability, dispatch and execution
+# -------------------------------------
+
+"""
+    blocksparse_reason(C, A, pA, conjA, B, pB, conjB, pAB) -> Union{Nothing, String}
+
+Why this contraction cannot be done with cuTENSOR's block-sparse backend, or `nothing` if it
+can. Returning the reason rather than a `Bool` is what lets `strict = true` and the `@debug`
+message say something useful. Tensor *types* are handled by dispatch, not here.
+"""
+function blocksparse_reason(
+        C::CuTensorMapAny, A::CuTensorMapAny, pA::Index2Tuple, conjA::Bool,
+        B::CuTensorMapAny, pB::Index2Tuple, conjB::Bool, pAB::Index2Tuple
+    )
+    T = scalartype(C)
+    T <: BLOCKSPARSE_TYPES || return "unsupported scalar type $T"
+    (scalartype(A) === T && scalartype(B) === T) ||
+        return "mixed scalar types ($(scalartype(A)), $(scalartype(B)), $T)"
+
+    I = sectortype(C)
+    blocksparse_compatible(I) ||
+        return "sector type $I has non-trivial fusion, braiding or duality data"
+
+    numind(A) <= MAX_BLOCKSPARSE_MODES || return "A has more than $MAX_BLOCKSPARSE_MODES modes"
+    numind(B) <= MAX_BLOCKSPARSE_MODES || return "B has more than $MAX_BLOCKSPARSE_MODES modes"
+    numind(C) <= MAX_BLOCKSPARSE_MODES || return "C has more than $MAX_BLOCKSPARSE_MODES modes"
+
+    isempty(pA[2]) && return "outer products are not supported"
+    numind(C) == 0 && return "scalar output is not supported"
+    (dim(A) > 0 && dim(B) > 0 && dim(C) > 0) || return "empty tensor"
+
+    # aliasing: cuTENSOR requires that A and B do not overlap the elements written to D
+    (C === A || C === B) && return "the output aliases an input"
+
+    # remaining layout validation, run here rather than in `bs_descriptor` so that a rejected
+    # space produces a fallback rather than an error
+    for t in (C, A, B)
+        try
+            blocksparsestructure(space(t))
+        catch e
+            e isa BlockSparseUnsupported && return e.msg
+            rethrow()
+        end
+    end
+    return nothing
+end
+
+# anything that is not a CUDA-backed `TensorMap` is out of scope by dispatch
+function blocksparse_reason(
+        C::AbstractTensorMap, A::AbstractTensorMap, ::Index2Tuple, ::Bool,
+        B::AbstractTensorMap, ::Index2Tuple, ::Bool, ::Index2Tuple
+    )
+    return "unsupported tensor types $(typeof(C)), $(typeof(A)), $(typeof(B)); " *
+        "the block-sparse backend requires CUDA-backed `TensorMap`s"
+end
+
+"whether this contraction will use the block-sparse backend, rather than falling back silently"
+blocksparse_supported(args...) = isnothing(blocksparse_reason(args...))
+
+# dispatch
+# --------
+# strictly more specific than the generic `_tensorcontract!` in C, A, B and `backend` at once
+function _tensorcontract!(
+        C::CuTensorMapAny,
+        A::CuTensorMapAny, pA::Index2Tuple, conjA::Bool,
+        B::CuTensorMapAny, pB::Index2Tuple, conjB::Bool,
+        pAB::Index2Tuple, α::Number, β::Number,
+        backend::CuTENSORBlockSparse, allocator
+    )
+    reason = blocksparse_reason(C, A, pA, conjA, B, pB, conjB, pAB)
+    if isnothing(reason)
+        key = BlockSparseKey(
+            space(C), space(A), space(B), pA, pB, pAB,
+            scalartype(C), false, CUDA.deviceid(CUDA.device())
+        )
+        # honour a backend-carried cache, so plan lifetime can be scoped to a hot loop
+        plan = blocksparse_plan(backend.plans, key)
+        return blocksparse_contract!(
+            C, A, pA, conjA, B, pB, conjB, pAB, α, β, plan, allocator
+        )
+    end
+    backend.strict && throw(BlockSparseUnsupported(reason))
+    @debug "falling back from the block-sparse backend" reason
+    return _generic_tensorcontract!(
+        C, A, pA, conjA, B, pB, conjB, pAB, α, β, backend.fallback, allocator
+    )
+end
+
+# a plan is a fully specialized backend
+function _tensorcontract!(
+        C::CuTensorMapAny,
+        A::CuTensorMapAny, pA::Index2Tuple, conjA::Bool,
+        B::CuTensorMapAny, pB::Index2Tuple, conjB::Bool,
+        pAB::Index2Tuple, α::Number, β::Number,
+        plan::BlockSparsePlan, allocator
+    )
+    @boundscheck check_plan(plan, C, A, pA, B, pB, pAB)
+    return blocksparse_contract!(
+        C, A, pA, conjA, B, pB, conjB, pAB, α, β, plan, allocator
+    )
+end
+
+# execution
+# ---------
+"""
+    blocksparse_contract!(C, A, pA, conjA, B, pB, conjB, pAB, α, β, plan, allocator)
+
+Execute `C = α ⋅ opA(A) ⋅ opB(B) + β ⋅ C` as a single block-sparse contraction.
+
+Because `pA`, `pB` and `pAB` only determine cuTENSOR mode labels, no permutation, fusion tree
+transformation or temporary is needed for bosonic sectors, with two exceptions: cuTENSOR
+accepts only `OP_IDENTITY`, so a complex operand needing conjugation is materialized first,
+and a fermionic sector needs a per-block sign, see
+[`TensorKit.blocksparse_contract_signs`](@ref).
+"""
+function blocksparse_contract!(
+        C::CuTensorMapAny,
+        A::CuTensorMapAny, pA::Index2Tuple, conjA::Bool,
+        B::CuTensorMapAny, pB::Index2Tuple, conjB::Bool,
+        pAB::Index2Tuple, α::Number, β::Number,
+        plan::BlockSparsePlan, allocator
+    )
+    T = scalartype(C)
+    # precomputed with the plan, and `nothing` in every field when nothing needs correcting
+    signs = @inbounds plan.signs[_signs_index(conjA, conjB)]
+    needconjA = conjA && T <: Complex
+    needconjB = conjB && T <: Complex
+    # copied rather than scaled in place because `A === B` is legal: with distinct `signs.A`
+    # and `signs.B` an in-place scaling of one would corrupt the other
+    copyA = needconjA || !isnothing(signs.A)
+    copyB = needconjB || !isnothing(signs.B)
+
+    A′ = copyA ? _scratch_operand(A, needconjA, signs.A, allocator) : A
+    B′ = copyB ? _scratch_operand(B, needconjB, signs.B, allocator) : B
+    try
+        if isnothing(signs.C)
+            _execute!(plan, C, A′, B′, α, β)
+        else
+            # `β⋅C + α⋅sC ⊙ naive == sC ⊙ (β⋅sC⁻¹ ⊙ C + α⋅naive)`: correcting without a temporary
+            prescaled = !iszero(β)
+            prescaled && _scale_subblocks!(C, signs.C, true)
+            try
+                _execute!(plan, C, A′, B′, α, β)
+            catch
+                # undo the pre-scaling, but *only* if it ran: a failed `β == 0` call may never
+                # have touched the data at all
+                prescaled && _scale_subblocks!(C, signs.C)
+                rethrow()
+            end
+            _scale_subblocks!(C, signs.C)
+        end
+    finally
+        copyA && TO.tensorfree!(A′, allocator)
+        copyB && TO.tensorfree!(B′, allocator)
+    end
+    return C
+end
+
+"materialize `conj(t)` and/or `signs ⊙ t` into a scratch tensor taken from `allocator`"
+function _scratch_operand(t::CuTensorMapAny, doconj::Bool, signs, allocator)
+    out = TO.tensoralloc(typeof(t), space(t), Val(true), allocator)
+    # the space is unchanged, so the plan and its descriptors still apply
+    if isnothing(signs)
+        # nothing to scale, so a single whole-array launch beats one launch per subblock
+        doconj ? (out.data .= conj.(t.data)) : copyto!(out.data, t.data)
+    else
+        _scale_subblocks!(out, t, signs, doconj)
+    end
+    return out
+end
+
+function _execute!(
+        plan::BlockSparsePlan, C::CuTensorMapAny, A::CuTensorMapAny, B::CuTensorMapAny,
+        α::Number, β::Number
+    )
+    ptrsA = block_pointers(A)
+    ptrsB = block_pointers(B)
+    ptrsC = block_pointers(C)
+
+    ST = plan.scalartype
+    αref = Ref{ST}(α)
+    βref = Ref{ST}(β)
+    wssize = plan.workspacesize
+
+    if iszero(wssize)
+        _blocksparse_ccall!(plan, αref, ptrsA, ptrsB, βref, ptrsC, CuPtr{Cvoid}(0), 0)
+    else
+        with_workspace(wssize) do workspace
+            _blocksparse_ccall!(
+                plan, αref, ptrsA, ptrsB, βref, ptrsC, pointer(workspace), wssize
+            )
+        end
+    end
+    return C
+end
+
+# called directly rather than through `cuTENSOR.contractBS!`: that helper materializes a view
+# per block, uses the workspace we detached, and mistypes `workspace` as `Ptr{CuPtr{Cvoid}}`
+function _blocksparse_ccall!(plan, αref, ptrsA, ptrsB, βref, ptrsC, ws, wssize)
+    GC.@preserve ptrsA ptrsB ptrsC αref βref begin
+        status = @ccall cuTENSOR.libcutensor.cutensorBlockSparseContract(
+            cuTENSOR.handle()::cuTENSOR.cutensorHandle_t,
+            plan.plan::cuTENSOR.cutensorPlan_t,
+            αref::Ptr{Cvoid}, ptrsA::Ptr{CuPtr{Cvoid}}, ptrsB::Ptr{CuPtr{Cvoid}},
+            βref::Ptr{Cvoid}, ptrsC::Ptr{CuPtr{Cvoid}}, ptrsC::Ptr{CuPtr{Cvoid}},
+            ws::CuPtr{Cvoid}, UInt64(wssize)::UInt64,
+            CUDA.stream()::cuTENSOR.cudaStream_t
+        )::cuTENSOR.cutensorStatus_t
+        status == cuTENSOR.CUTENSOR_STATUS_SUCCESS ||
+            throw(cuTENSOR.CUTENSORError(status))
+    end
+    return nothing
+end

--- a/ext/TensorKitcuTENSORExt/descriptors.jl
+++ b/ext/TensorKitcuTENSORExt/descriptors.jl
@@ -1,0 +1,35 @@
+# Block-sparse tensor descriptors
+# -------------------------------
+# The low-level `CuTensorBSDescriptor` constructor is used deliberately: the `::CuTensorBS`
+# one asserts contiguous blocks, whereas a TensorKit subblock is a strided view.
+
+"build a cuTENSOR block-sparse descriptor for the layout of `W` with scalar type `T`"
+function bs_descriptor(W::HomSpace, ::Type{T}) where {T}
+    s = blocksparsestructure(W)
+    N = nmodes(s)
+    N <= MAX_BLOCKSPARSE_MODES || throw(
+        BlockSparseUnsupported(
+            "cuTENSOR's block-sparse backend supports at most $MAX_BLOCKSPARSE_MODES modes, got $N"
+        )
+    )
+    # cuTENSOR wants one permutation sorting every block's strides ascending; `degeneracystructure`
+    # makes that the identity. `vec` on a `Matrix` is a zero-copy reshape.
+    return cuTENSOR.CuTensorBSDescriptor(
+        Int32(N), Int64(nblocks(s)),
+        s.numsections, s.extent, vec(s.coordinates), vec(s.strides), T
+    )
+end
+
+"fill the host array `ptrs` with a device pointer to each non-zero block of `t`, in canonical order"
+function block_pointers!(ptrs::Vector{CuPtr{Cvoid}}, t::CuTensorMapAny)
+    s = blocksparsestructure(space(t))
+    base = convert(CuPtr{Cvoid}, pointer(t.data))
+    elsz = sizeof(scalartype(t))
+    resize!(ptrs, nblocks(s))
+    @inbounds for i in eachindex(ptrs)
+        ptrs[i] = base + s.offsets[i] * elsz
+    end
+    return ptrs
+end
+
+block_pointers(t::CuTensorMapAny) = block_pointers!(Vector{CuPtr{Cvoid}}(), t)

--- a/ext/TensorKitcuTENSORExt/plan.jl
+++ b/ext/TensorKitcuTENSORExt/plan.jl
@@ -1,0 +1,211 @@
+# Block-sparse contraction plans
+# ------------------------------
+
+"""
+    BlockSparseKey
+
+Everything a block-sparse contraction plan depends on, which notably excludes the tensor
+data: block pointers are supplied at execution time, which is what makes plans reusable.
+A cuTENSOR plan is only valid on the device active at creation time, hence the `device` field.
+"""
+struct BlockSparseKey{SC, SA, SB}
+    VC::SC
+    VA::SA
+    VB::SB
+    pA::Index2Tuple
+    pB::Index2Tuple
+    pAB::Index2Tuple
+    scalartype::DataType
+    jit::Bool
+    device::Int
+end
+
+function Base.hash(k::BlockSparseKey, h::UInt)
+    h = hash(k.VC, hash(k.VA, hash(k.VB, h)))
+    h = hash(k.pA, hash(k.pB, hash(k.pAB, h)))
+    return hash(k.scalartype, hash(k.jit, hash(k.device, h)))
+end
+function Base.:(==)(a::BlockSparseKey, b::BlockSparseKey)
+    return a.VC == b.VC && a.VA == b.VA && a.VB == b.VB &&
+        a.pA == b.pA && a.pB == b.pB && a.pAB == b.pAB &&
+        a.scalartype === b.scalartype && a.jit == b.jit && a.device == b.device
+end
+
+"""
+    BlockSparsePlan <: TensorOperations.AbstractBackend
+
+A precomputed cuTENSOR block-sparse contraction, usable directly as a backend:
+
+```julia
+plan = plan_contract(C, A, pA, B, pB, pAB)
+@tensor backend = plan C[a, b] = A[a, c] * B[c, b]
+```
+
+The device workspace is deliberately *not* retained: two tasks executing the same cached plan
+on different streams would race on a shared workspace. Only its size is kept, and the buffer
+is taken from the memory pool per call.
+
+The per-block sign correction a fermionic sector needs is carried here too. It depends on
+`conjA`/`conjB`, which are not part of a plan's identity, so all four combinations are derived
+up front and indexed by [`_signs_index`](@ref).
+
+See also [`plan_contract`](@ref), [`CuTENSORBlockSparse`](@ref).
+"""
+struct BlockSparsePlan <: TO.AbstractBackend
+    plan::cuTENSOR.CuTensorPlan
+    workspacesize::Int
+    scalartype::DataType
+    signs::NTuple{4, BlockSparseSigns}
+    key::Any
+end
+
+"index of the `(conjA, conjB)` combination into a plan's `signs` tuple"
+_signs_index(conjA::Bool, conjB::Bool) = 1 + conjA + 2 * conjB
+
+function Base.show(io::IO, p::BlockSparsePlan)
+    k = p.key::BlockSparseKey
+    return print(
+        io, "BlockSparsePlan(", k.VA, ", ", k.VB, " -> ", k.VC,
+        "; ", p.scalartype, ", workspace = ", Base.format_bytes(p.workspacesize), ")"
+    )
+end
+
+CUDA.unsafe_free!(p::BlockSparsePlan) = CUDA.unsafe_free!(p.plan)
+
+# small by default: an entry holds a cuTENSOR plan handle, and with JIT a compiled kernel
+const BLOCKSPARSE_PLAN_CACHE_SIZE = Ref(128)
+const BLOCKSPARSE_PLAN_CACHE = LRU{Any, BlockSparsePlan}(;
+    maxsize = BLOCKSPARSE_PLAN_CACHE_SIZE[]
+)
+
+"""
+    blocksparse_plancache_size!(n)
+
+Set the maximum number of cuTENSOR block-sparse contraction plans kept in the global cache.
+"""
+function blocksparse_plancache_size!(n::Integer)
+    BLOCKSPARSE_PLAN_CACHE_SIZE[] = n
+    resize!(BLOCKSPARSE_PLAN_CACHE; maxsize = n)
+    return n
+end
+
+"create the cuTENSOR descriptor and plan; runs the kernel-selection heuristic that caching saves"
+function _create_plan(key::BlockSparseKey)
+    T = key.scalartype
+    descA = bs_descriptor(key.VA, T)
+    descB = bs_descriptor(key.VB, T)
+    descC = bs_descriptor(key.VC, T)
+    modeA, modeB, modeC = map(
+        l -> collect(Cint, l), TO.contract_labels(key.pA, key.pB, key.pAB)
+    )
+    computetype = cuTENSOR.contraction_compute_types[(T, T, T)]
+
+    desc = Ref{cuTENSOR.cutensorOperationDescriptor_t}()
+    # `descD` must be the *same* descriptor as `descC`, and C and D must share their layout
+    GC.@preserve descA descB descC begin
+        cuTENSOR.cutensorCreateBlockSparseContraction(
+            cuTENSOR.handle(), desc,
+            descA, modeA, cuTENSOR.OP_IDENTITY,
+            descB, modeB, cuTENSOR.OP_IDENTITY,
+            descC, modeC, cuTENSOR.OP_IDENTITY,
+            descC, modeC, computetype
+        )
+    end
+    pref = Ref{cuTENSOR.cutensorPlanPreference_t}()
+    cuTENSOR.cutensorCreatePlanPreference(
+        cuTENSOR.handle(), pref, cuTENSOR.ALGO_DEFAULT,
+        key.jit ? cuTENSOR.JIT_MODE_DEFAULT : cuTENSOR.JIT_MODE_NONE
+    )
+
+    plan = cuTENSOR.CuTensorPlan(desc[], pref[])
+    cuTENSOR.cutensorDestroyOperationDescriptor(desc[])
+    cuTENSOR.cutensorDestroyPlanPreference(pref[])
+
+    # detach the workspace, see the `BlockSparsePlan` docstring
+    workspacesize = sizeof(plan.workspace)
+    scalartype = plan.scalar_type
+    CUDA.unsafe_free!(plan.workspace)
+    plan.workspace = CUDA.CuVector{UInt8, CUDA.DeviceMemory}(undef, 0)
+
+    # all four conjugation combinations, since they are not part of the key; this decoding is
+    # the inverse of `_signs_index`, a correspondence pinned by a test
+    signs = ntuple(4) do i
+        conjA, conjB = isodd(i - 1), (i - 1) >= 2
+        return blocksparse_contract_signs(
+            key.VC, key.VA, key.pA, conjA, key.VB, key.pB, conjB, key.pAB
+        )
+    end
+
+    return BlockSparsePlan(plan, workspacesize, scalartype, signs, key)
+end
+
+"look `key` up in the global plan cache, creating the plan on a miss"
+function blocksparse_plan(key::BlockSparseKey)
+    return get!(() -> _create_plan(key), BLOCKSPARSE_PLAN_CACHE, key)
+end
+blocksparse_plan(cache, key::BlockSparseKey) = get!(() -> _create_plan(key), cache, key)
+blocksparse_plan(::Nothing, key::BlockSparseKey) = blocksparse_plan(key)
+
+# public API
+# ----------
+function plan_contract(
+        ::Type{T}, VC::HomSpace, VA::HomSpace, pA::Index2Tuple,
+        VB::HomSpace, pB::Index2Tuple, pAB::Index2Tuple;
+        jit::Bool = false
+    ) where {T}
+    T <: BLOCKSPARSE_TYPES || throw(
+        BlockSparseUnsupported(
+            "cuTENSOR's block-sparse backend does not support scalar type $T"
+        )
+    )
+    # a plan is the one entry point that never consults `blocksparse_reason`, so the sector
+    # gate has to be applied here rather than failing much later at execution
+    I = sectortype(VC)
+    blocksparse_compatible(I) || throw(
+        BlockSparseUnsupported(
+            "sector type $I has non-trivial fusion, braiding or duality data"
+        )
+    )
+    key = BlockSparseKey(
+        VC, VA, VB, pA, pB, pAB, T, jit, CUDA.deviceid(CUDA.device())
+    )
+    return blocksparse_plan(key)
+end
+
+function plan_contract(
+        C::AbstractTensorMap, A::AbstractTensorMap, pA::Index2Tuple,
+        B::AbstractTensorMap, pB::Index2Tuple, pAB::Index2Tuple; kwargs...
+    )
+    return plan_contract(
+        scalartype(C), space(C), space(A), pA, space(B), pB, pAB; kwargs...
+    )
+end
+
+"verify `p` was built for this contraction; reusing one would silently read the wrong blocks"
+function check_plan(
+        p::BlockSparsePlan, C::AbstractTensorMap,
+        A::AbstractTensorMap, pA::Index2Tuple,
+        B::AbstractTensorMap, pB::Index2Tuple, pAB::Index2Tuple
+    )
+    k = p.key::BlockSparseKey
+    # a plan bypasses `blocksparse_reason`, and the fermionic output correction writes into `C`
+    # *before* the contraction, so an aliased operand would be modified rather than merely raced on
+    (C === A || C === B) && throw(
+        ArgumentError("the output aliases an input, which cuTENSOR does not permit")
+    )
+    expected = BlockSparseKey(
+        space(C), space(A), space(B), pA, pB, pAB,
+        scalartype(C), k.jit, CUDA.deviceid(CUDA.device())
+    )
+    k == expected || throw(
+        ArgumentError(
+            lazy"""
+            this `BlockSparsePlan` was not built for this contraction:
+              plan:     $(k.VA), $(k.VB) -> $(k.VC) with $(k.pA), $(k.pB), $(k.pAB) on device $(k.device)
+              provided: $(expected.VA), $(expected.VB) -> $(expected.VC) with $(expected.pA), $(expected.pB), $(expected.pAB) on device $(expected.device)
+            Build one plan per distinct contraction, or pass `CuTENSORBlockSparse()` to use the plan cache.
+            """
+        )
+    )
+    return nothing
+end

--- a/src/TensorKit.jl
+++ b/src/TensorKit.jl
@@ -98,6 +98,9 @@ export catdomain, catcodomain, absorb, absorb!
 export @tensor, @tensoropt, @ncon, ncon, @planar, @plansor
 export scalar, add!, contract!
 
+# backends
+export CuTENSORBlockSparse, blocksparse_compatible, plan_contract
+
 # truncation schemes
 export notrunc, truncrank, trunctol, truncfilter, truncspace, truncerror
 
@@ -261,6 +264,7 @@ include("tensors/adjoint.jl")
 include("tensors/linalg.jl")
 include("tensors/vectorinterface.jl")
 include("tensors/tensoroperations.jl")
+include("tensors/blocksparse.jl")
 include("tensors/treetransformers.jl")
 include("tensors/indexmanipulations.jl")
 include("tensors/diagonal.jl")

--- a/src/spaces/structure.jl
+++ b/src/spaces/structure.jl
@@ -88,6 +88,7 @@ strides that depend on the degeneracy (multiplicity) dimensions. Specific to a g
   same order as [`sectorstructure`](@ref)`.blocksectors`.
 - `subblockstructure`: `Vector` of [`StridedStructure`](@ref) `(sizes, strides, offset)`
   values, one per fusion tree pair, in the same order as [`sectorstructure`](@ref)`.fusiontrees`.
+  The strides of extent-1 axes are normalized, so that every stride tuple is monotone.
 
 See also [`degeneracystructure`](@ref), [`SectorStructure`](@ref).
 """
@@ -192,7 +193,9 @@ function _subblock_strides(subsz, sz, str)
     strides = Strided.StridedViews._computereshapestrides(subsz, sz_simplify...)
     isnothing(strides) &&
         throw(ArgumentError("unexpected error in computing subblock strides"))
-    return strides
+    # normalize the unobservable strides of extent-1 axes, so that every stored stride
+    # tuple is monotone -- which is what block-sparse backends require
+    return Strided.StridedViews._normalizestrides(subsz, strides)
 end
 
 CacheStyle(::typeof(degeneracystructure), ::HomSpace) = GlobalLRUCache()

--- a/src/tensors/backends.jl
+++ b/src/tensors/backends.jl
@@ -1,3 +1,179 @@
+# Block-sparse contraction backend
+# --------------------------------
+
+"""
+    BlockSparseUnsupported(msg) <: Exception
+
+Thrown when a tensor or operation cannot be expressed in the block-sparse form required by
+[`CuTENSORBlockSparse`](@ref). Usually caught internally to trigger a fallback.
+"""
+struct BlockSparseUnsupported <: Exception
+    msg::String
+end
+Base.showerror(io::IO, e::BlockSparseUnsupported) =
+    print(io, "BlockSparseUnsupported: ", e.msg)
+
+"""
+    blocksparse_compatible(::Type{I}) where {I <: Sector} -> Bool
+
+Whether every fusion tree transformation of `I` reduces to a single scalar per fusion tree
+pair, so that a contraction may be carried out on the raw block data *up to a per-block
+rescaling* — which a caller doing so itself must apply, see
+[`TensorKit.blocksparse_contract_signs`](@ref).
+
+Beware that this is weaker than "the raw block data may be contracted directly": that only
+holds in the first of the two cases below. The trait additionally excludes `Trivial`, which
+satisfies the property but is better served by the dense path, so a `true` answer means "this
+backend supports `I`" rather than any one mathematical property.
+
+The property requires unique fusion and trivial F-symbols. There are two cases:
+
+  - Trivial R-symbols, twists and Frobenius–Schur phases, i.e. `fusiontensor((f₁, f₂)) == 1`
+    for every fusion tree pair. A stored subblock then coincides with the corresponding slice
+    of the dense array, the identity `F_C = F_A · F_B` holds for every matching triple, and
+    the raw block contraction is directly correct. Among the sectors shipped with TensorKit
+    this means the irreps of abelian *groups* and products thereof.
+  - Fermionic braiding, where R-symbols and twists are `±1`. The raw block contraction then
+    differs from the categorical one by a per-block sign, which the backend corrects for; see
+    [`TensorKit.blocksparse_contract_signs`](@ref).
+
+The default is `false`, deliberately: `FusionStyle(I) === UniqueFusion()` is *not*
+sufficient. `ZNElement`/`Z3Element` have unique fusion, but their anyonic R-symbols are
+genuine phases rather than signs, which is **unvalidated** here, so they fall back.
+
+See also [`CuTENSORBlockSparse`](@ref).
+"""
+blocksparse_compatible(::Type{<:Sector}) = false
+blocksparse_compatible(::Type{<:TensorKitSectors.AbelianIrrep}) = true
+# fermion parity has unique fusion and trivial F-symbols, with R-symbols and twists in {±1}
+blocksparse_compatible(::Type{FermionParity}) = true
+Base.@assume_effects :foldable function blocksparse_compatible(
+        ::Type{ProductSector{T}}
+    ) where {T <: Tuple}
+    return all(blocksparse_compatible, fieldtypes(T))
+end
+blocksparse_compatible(t::AbstractTensorMap) = blocksparse_compatible(sectortype(t))
+
+"""
+    CuTENSORBlockSparse(; fallback = TensorOperations.DefaultBackend(), strict = false, plans = nothing)
+
+Backend that maps a symmetric tensor contraction onto a *single* block-sparse contraction of
+the underlying storage, with no fusion tree transformation and no intermediate permutations:
+the index tuples only determine mode labels. Currently implemented for `TensorMap`s with
+CUDA storage, via cuTENSOR's block-sparse API, and only for sector types satisfying
+[`blocksparse_compatible`](@ref).
+
+For fermionic sectors the raw block contraction differs from the categorical one by a
+per-block sign, which is corrected by scaling blocks. That path is still free of any fusion
+tree transformation, but it does allocate one temporary per operand whose signs are
+non-trivial.
+
+Requires both `CUDA.jl` and `cuTENSOR.jl` to be loaded. Note that NVIDIA documents the
+underlying block-sparse API as a *public beta* with no guarantee of stability across
+releases, which is why this backend is opt-in rather than selected automatically:
+
+```julia
+@tensor backend = CuTENSORBlockSparse() C[a, b] = A[a, c] * B[c, b]
+```
+
+## Keywords
+- `fallback`: backend used for contractions that cannot be expressed in block-sparse form,
+  and for all non-contraction operations.
+- `strict`: throw a [`BlockSparseUnsupported`](@ref) instead of falling back silently. Off by
+  default because a single `@tensor` network routinely mixes supported and unsupported
+  contractions; turn it on to assert that you are on the fast path.
+- `plans`: a plan cache to use instead of the global one, so that plan lifetime can be scoped
+  to a hot loop. `nothing` uses the global cache.
+
+See also [`blocksparse_compatible`](@ref).
+"""
+struct CuTENSORBlockSparse{B <: AbstractBackend, C} <: AbstractBackend
+    fallback::B
+    strict::Bool
+    plans::C
+end
+function CuTENSORBlockSparse(;
+        fallback::AbstractBackend = TO.DefaultBackend(), strict::Bool = false,
+        plans = nothing
+    )
+    return CuTENSORBlockSparse(fallback, strict, plans)
+end
+
+# only contraction has a block-sparse form; without these, any permutation or trace in an
+# `@tensor` network would reach the leaf `TO.tensoradd!` and hit an "unknown backend" error
+function TO.tensoradd!(
+        C::AbstractTensorMap, A::AbstractTensorMap, pA::Index2Tuple, conjA::Bool,
+        α::Number, β::Number, backend::CuTENSORBlockSparse, allocator
+    )
+    return TO.tensoradd!(C, A, pA, conjA, α, β, backend.fallback, allocator)
+end
+function TO.tensortrace!(
+        C::AbstractTensorMap, A::AbstractTensorMap, p::Index2Tuple, q::Index2Tuple,
+        conjA::Bool, α::Number, β::Number, backend::CuTENSORBlockSparse, allocator
+    )
+    return TO.tensortrace!(C, A, p, q, conjA, α, β, backend.fallback, allocator)
+end
+
+"""
+    plan_contract(C, A, pA, B, pB, pAB; kwargs...) -> AbstractBackend
+    plan_contract(::Type{T}, VC, VA, pA, VB, pB, pAB; kwargs...) -> AbstractBackend
+
+Precompute everything a block-sparse contraction needs that does not depend on the tensor
+*data*, and return it as a backend that can be handed straight to `@tensor` or
+`tensorcontract!`:
+
+```julia
+plan = plan_contract(C, A, pA, B, pB, pAB)
+for i in 1:nsweeps
+    @tensor backend = plan C[a, b] = A[a, c] * B[c, b]
+end
+```
+
+The block-sparse description of a contraction — the sparsity pattern, the block strides and
+the selected kernel — is a pure function of the spaces, the index tuples and the scalar type;
+the block pointers are only supplied at execution time. Hoisting a plan out of a loop is
+therefore safe, and worth doing whenever the spaces are fixed across many iterations, as in an
+MPS sweep at fixed bond dimension.
+
+The second form takes spaces rather than tensors, so a plan can be built before the tensors
+exist. Reusing a plan with spaces or index tuples other than those it was built for is an
+error, checked under `@boundscheck`.
+
+Plans are cached automatically, so calling this is not required for reuse; it exists to avoid
+even the cache lookup, and to give explicit control over plan lifetime.
+
+For a fermionic sector this includes the per-block sign correction. That depends additionally
+on `conjA`/`conjB`, which are not part of a plan's identity, so a plan carries the correction
+for all four combinations and picks one at execution time — no separate lookup, and no way for
+the correction to disagree with the descriptors it was built alongside.
+
+Requires `CUDA.jl` and `cuTENSOR.jl`. See also [`CuTENSORBlockSparse`](@ref).
+"""
+function plan_contract end
+
+# not CUDA-backed, so the extension's more specific method never applies: fall back
+function _tensorcontract!(
+        C::AbstractTensorMap,
+        A::AbstractTensorMap, pA::Index2Tuple, conjA::Bool,
+        B::AbstractTensorMap, pB::Index2Tuple, conjB::Bool,
+        pAB::Index2Tuple, α::Number, β::Number,
+        backend::CuTENSORBlockSparse, allocator
+    )
+    if backend.strict
+        throw(
+            BlockSparseUnsupported(
+                lazy"""
+                no block-sparse contraction available for tensor types $(typeof(C)), $(typeof(A)) and $(typeof(B)).
+                This requires CUDA-backed `TensorMap`s, with both `CUDA.jl` and `cuTENSOR.jl` loaded.
+                """
+            )
+        )
+    end
+    return _generic_tensorcontract!(
+        C, A, pA, conjA, B, pB, conjB, pAB, α, β, backend.fallback, allocator
+    )
+end
+
 # Scheduler implementation
 # ------------------------
 function select_scheduler(scheduler = OhMyThreads.Implementation.NotGiven(); kwargs...)

--- a/src/tensors/blocksparse.jl
+++ b/src/tensors/blocksparse.jl
@@ -1,0 +1,241 @@
+# Block-sparse description of a `HomSpace`
+# ----------------------------------------
+# Layout bookkeeping for backends handing raw block data to a block-sparse library.
+
+"""
+    BlockSparseStructure
+
+Description of a `HomSpace` as a block-sparse tensor of `N = nmodes(s)` modes: which sections
+each mode is divided into, and where each non-zero block lives in the flat data vector.
+
+Blocks are enumerated in the order of [`fusiontrees`](@ref), which is the canonical order
+that must be used consistently for every subsequent operation on the same space.
+
+## Fields
+- `numsections`: number of sections of each mode, length `N`.
+- `extent`: extents of the sections of each mode, length `sum(numsections)`, ordered
+  mode-major (all sections of mode 1, then all sections of mode 2, ...).
+- `coordinates`: **zero-based** section coordinate of each non-zero block, as an
+  `N × nblocks` matrix, one column per block.
+- `strides`: strides of each non-zero block, same shape and order as `coordinates`. These
+  come straight from [`subblockstructure`](@ref), and are therefore normalized and monotone.
+- `offsets`: **zero-based** offset of each non-zero block into the flat data vector, length
+  `nblocks`.
+
+See also [`blocksparsestructure`](@ref), [`blocksparse_compatible`](@ref).
+"""
+struct BlockSparseStructure
+    numsections::Vector{Int32}
+    extent::Vector{Int64}
+    coordinates::Matrix{Int32}
+    strides::Matrix{Int64}
+    offsets::Vector{Int64}
+end
+
+nmodes(s::BlockSparseStructure) = length(s.numsections)
+nblocks(s::BlockSparseStructure) = length(s.offsets)
+
+"""
+    blocksparsestructure(W::HomSpace) -> BlockSparseStructure
+
+Compute the [`BlockSparseStructure`](@ref) of `W`. The result is cached per `HomSpace`,
+since it depends on the degeneracy dimensions through the block strides and offsets.
+
+Throws [`BlockSparseUnsupported`](@ref) if `W` has no modes or no non-zero blocks.
+
+See also [`blocksparse_compatible`](@ref).
+""" blocksparsestructure(::HomSpace)
+
+@cached function blocksparsestructure(W::HomSpace)::BlockSparseStructure
+    N₁, N₂ = numout(W), numin(W)
+    N = N₁ + N₂
+    I = sectortype(W)
+    codom, dom = codomain(W), domain(W)
+
+    N > 0 || throw(BlockSparseUnsupported("a scalar has no block-sparse description"))
+
+    # labels come from `codomain(W)[i]`/`domain(W)[j]`, not `space(W, i)`, so that
+    # two contractible modes get matching section indices.
+    modespace(i) = i <= N₁ ? codom[i] : dom[i - N₁]
+    seclists = ntuple(i -> collect(sectors(modespace(i))), N)
+
+    numsections = Int32[length(l) for l in seclists]
+    any(iszero, numsections) && throw(BlockSparseUnsupported("`$W` has an empty mode"))
+
+    extent = Vector{Int64}(undef, sum(numsections))
+    k = 0
+    for i in 1:N
+        V = modespace(i)
+        for c in seclists[i]
+            extent[k += 1] = dim(V, c)
+        end
+    end
+    secindex = ntuple(N) do i
+        d = Dict{I, Int32}()
+        for (j, c) in enumerate(seclists[i])
+            d[c] = Int32(j - 1)
+        end
+        return d
+    end
+
+    trees = fusiontrees(W)
+    substructure = degeneracystructure(W).subblockstructure
+    L = length(trees)
+    L > 0 || throw(BlockSparseUnsupported("`$W` has no non-zero blocks"))
+
+    coordinates = Matrix{Int32}(undef, N, L)
+    strides = Matrix{Int64}(undef, N, L)
+    offsets = Vector{Int64}(undef, L)
+
+    for b in 1:L
+        f₁, f₂ = gettokenvalue(trees, b)
+        _, st, offset = substructure[b]
+        @inbounds for i in 1:N₁
+            coordinates[i, b] = secindex[i][f₁.uncoupled[i]]
+        end
+        @inbounds for j in 1:N₂
+            coordinates[N₁ + j, b] = secindex[N₁ + j][f₂.uncoupled[j]]
+        end
+        @inbounds for i in 1:N
+            strides[i, b] = st[i]
+        end
+        offsets[b] = offset
+    end
+
+    return BlockSparseStructure(numsections, extent, coordinates, strides, offsets)
+end
+
+CacheStyle(::typeof(blocksparsestructure), ::HomSpace) = GlobalLRUCache()
+
+# Per-block sign corrections
+# --------------------------
+# For a sector whose fusion tree transformations are all scalar, a raw block-wise contraction
+# differs from the categorical one by a per-block scalar, factorizing as `sA(a)·sB(b)·sC(c)`.
+
+"""
+    BlockSparseSigns{T}
+
+The per-block scalars that turn a raw block-wise contraction into TensorKit's categorical
+one, one entry per non-zero block of each of the three tensors, in the block order of
+[`BlockSparseStructure`](@ref).
+
+A field is `nothing` when every scalar of that tensor is one, so that the correction can be
+skipped entirely. All three are `nothing` for bosonic sectors.
+
+See also [`TensorKit.blocksparse_contract_signs`](@ref).
+"""
+struct BlockSparseSigns{T}
+    A::Union{Nothing, Vector{T}}
+    B::Union{Nothing, Vector{T}}
+    C::Union{Nothing, Vector{T}}
+end
+
+istrivial(s::BlockSparseSigns) = isnothing(s.A) && isnothing(s.B) && isnothing(s.C)
+
+# the uncoupled sector carried by leg `j` of a tree pair, with `N₁` codomain legs
+function _legsector((f₁, f₂)::FusionTreePair, N₁::Int, j::Int)
+    return j <= N₁ ? f₁.uncoupled[j] : f₂.uncoupled[j - N₁]
+end
+
+# a tensor whose scalars are all one needs no correction: the common case even for fermions
+_nothing_if_trivial(signs) = all(isone, signs) ? nothing : signs
+
+"""
+    blocksparse_contract_signs(WC, WA, pA, conjA, WB, pB, conjB, pAB) -> BlockSparseSigns
+
+Derive the per-block scalars that a block-sparse contraction of the raw block data must be
+corrected by to agree with `tensorcontract!(C, A, pA, conjA, B, pB, conjB, pAB, α, β)`.
+
+A pure function of the spaces and index tuples, and *not* cached: the backend derives it once
+per contraction plan rather than once per call, so a cache here would only ever be hit on a
+plan-cache miss. Callers repeating a contraction should hold on to the result the same way.
+
+Assumes that every fusion tree transformation of `sectortype(WA)` is scalar, i.e. that
+[`blocksparse_compatible`](@ref) holds; the scalars are derived from `permute` of a fusion
+tree pair, which for unique fusion returns a single `(tree, coeff)` pair.
+
+The correction to apply is: scale the blocks of `A` by `signs.A`, those of `B` by `signs.B`,
+contract, and scale the blocks of the result by `signs.C` before accumulating into `C`.
+
+See also [`TensorKit.BlockSparseSigns`](@ref).
+""" blocksparse_contract_signs
+
+function blocksparse_contract_signs(
+        WC::HomSpace, WA::HomSpace, pA::Index2Tuple, conjA::Bool,
+        WB::HomSpace, pB::Index2Tuple, conjB::Bool, pAB::Index2Tuple
+    )
+    I = sectortype(WA)
+    T = sectorscalartype(I)
+    # bosonic sectors have unit R-symbols and twists, so nothing to correct
+    BraidingStyle(I) isa Bosonic && return BlockSparseSigns{T}(nothing, nothing, nothing)
+
+    # the twist for a dual contracted leg is always attributable to `A`, since
+    # `domain(Anew) == codomain(Bnew)`.
+    sA = _blocksparse_operand_signs(T, WA, pA, conjA, true)
+    sB = _blocksparse_operand_signs(T, WB, pB, conjB, false)
+    sC = _blocksparse_output_signs(T, WC, length(pA[1]), pAB)
+    return BlockSparseSigns{T}(sA, sB, sC)
+end
+
+function _blocksparse_operand_signs(
+        ::Type{T}, W::HomSpace, p::Index2Tuple, isconj::Bool, twistcontracted::Bool
+    ) where {T}
+    # fold `conj` by moving to the adjoint space, exactly as `_generic_tensorcontract!` does
+    W★ = isconj ? adjoint(W) : W
+    p★ = isconj ? adjointtensorindices(W, p) : p
+    N₁ = numout(W★)
+    twistlegs = twistcontracted ? filter(j -> !isdual(W★[j]), p★[2]) : ()
+
+    trees = fusiontrees(W)
+    signs = Vector{T}(undef, length(trees))
+    for (i, f) in enumerate(trees)
+        f★ = isconj ? (f[2], f[1]) : f
+        coeff = last(permute(f★, p★))
+        for j in twistlegs
+            coeff *= twist(_legsector(f★, N₁, j))
+        end
+        signs[i] = coeff
+    end
+    return _nothing_if_trivial(signs)
+end
+
+"scale each subblock of `t` by its entry of `signs`, or by its conjugate if `inverse`"
+function _scale_subblocks!(t::AbstractTensorMap, signs, inverse::Bool = false)
+    # `StridedView(t.data, sz, str, offset)` is what `subblock` builds, minus the lookup
+    for (s, (sz, str, offset)) in zip(signs, values(subblockstructure(space(t))))
+        isone(s) && continue
+        sv = StridedView(t.data, sz, str, offset)
+        sv .*= inverse ? conj(s) : s
+    end
+    return t
+end
+
+"write `signs ⊙ src` into `dst`, conjugating first if `doconj`; every subblock is written"
+function _scale_subblocks!(
+        dst::AbstractTensorMap, src::AbstractTensorMap, signs, doconj::Bool
+    )
+    for (s, (sz, str, offset)) in zip(signs, values(subblockstructure(space(src))))
+        srcv = StridedView(src.data, sz, str, offset)
+        dstv = StridedView(dst.data, sz, str, offset)
+        dstv .= s .* (doconj ? conj(srcv) : srcv)
+    end
+    return dst
+end
+
+function _blocksparse_output_signs(
+        ::Type{T}, WC::HomSpace, nopenA::Int, pAB::Index2Tuple
+    ) where {T}
+    # the coefficient of the final `Cnew -> C` permutation, which the kernel does not apply
+    ipAB = TO.repartition(invperm(linearize(pAB)), nopenA)
+
+    trees = fusiontrees(WC)
+    signs = Vector{T}(undef, length(trees))
+    for (i, f) in enumerate(trees)
+        # permuting the other way gives the inverse, i.e. the conjugate for a unitary scalar
+        signs[i] = conj(last(permute(f, ipAB)))
+    end
+    return _nothing_if_trivial(signs)
+end
+
+# convenience accessors on tensors
+blocksparsestructure(t::AbstractTensorMap) = blocksparsestructure(space(t))

--- a/src/tensors/tensoroperations.jl
+++ b/src/tensors/tensoroperations.jl
@@ -136,6 +136,43 @@ function TO.tensorcontract!(
     )
     pAB′ = _canonicalize(pAB, C)
     @boundscheck spacecheck_contract(C, A, pA, conjA, B, pB, conjB, pAB′)
+    return _tensorcontract!(C, A, pA, conjA, B, pB, conjB, pAB′, α, β, backend, allocator)
+end
+
+"""
+    _tensorcontract!(C, A, pA, conjA, B, pB, conjB, pAB, α, β, backend, allocator)
+
+Backend-dispatchable core of [`TensorOperations.tensorcontract!`](@extref), called after
+`pAB` has been canonicalized and the spaces have been checked. This is the designated hook
+for a backend implementing a contraction by another route than the default
+fusion-tree/BLAS path: specialize on `backend`, and call [`_generic_tensorcontract!`](@ref)
+to fall back. Hooking here keeps `conjA`/`conjB` available as plain `Bool`s.
+"""
+function _tensorcontract!(
+        C::AbstractTensorMap,
+        A::AbstractTensorMap, pA::Index2Tuple, conjA::Bool,
+        B::AbstractTensorMap, pB::Index2Tuple, conjB::Bool,
+        pAB::Index2Tuple, α::Number, β::Number,
+        backend, allocator
+    )
+    return _generic_tensorcontract!(
+        C, A, pA, conjA, B, pB, conjB, pAB, α, β, backend, allocator
+    )
+end
+
+"""
+    _generic_tensorcontract!(C, A, pA, conjA, B, pB, conjB, pAB, α, β, backend, allocator)
+
+The default contraction implementation: resolve `conjA`/`conjB` into adjoints and hand off
+to [`contract!`](@ref), substituting a backend the default path understands.
+"""
+function _generic_tensorcontract!(
+        C::AbstractTensorMap,
+        A::AbstractTensorMap, pA::Index2Tuple, conjA::Bool,
+        B::AbstractTensorMap, pB::Index2Tuple, conjB::Bool,
+        pAB′::Index2Tuple, α::Number, β::Number,
+        backend, allocator
+    )
     if has_array_view(C) && has_array_view(A) && has_array_view(B)
         TO.tensorcontract!(C[], A[], pA, conjA, B[], pB, conjB, pAB′, α, β, backend, allocator)
         return C

--- a/test/cuda/blocksparse.jl
+++ b/test/cuda/blocksparse.jl
@@ -1,0 +1,351 @@
+using Test, TestExtras
+using CUDA, cuTENSOR
+using TensorKit
+using TensorOperations: TensorOperations as TO
+using TensorKit: BlockSparseUnsupported, blocksparsestructure
+
+@isdefined(TestSetup) || include("../setup.jl")
+using .TestSetup
+
+const CUDAExt = Base.get_extension(TensorKit, :TensorKitCUDAExt)
+const cuTENSORExt = Base.get_extension(TensorKit, :TensorKitcuTENSORExt)
+@assert !isnothing(CUDAExt) && !isnothing(cuTENSORExt)
+const CuTensorMap = getglobal(CUDAExt, :CuTensorMap)
+const blocksparse_supported = getglobal(cuTENSORExt, :blocksparse_supported)
+const blocksparse_reason = getglobal(cuTENSORExt, :blocksparse_reason)
+const check_plan = getglobal(cuTENSORExt, :check_plan)
+const _signs_index = getglobal(cuTENSORExt, :_signs_index)
+const bs_signs = getglobal(TensorKit, :blocksparse_contract_signs)
+const PLAN_CACHE = getglobal(cuTENSORExt, :BLOCKSPARSE_PLAN_CACHE)
+
+const bs = CuTENSORBlockSparse()
+const bs_strict = CuTENSORBlockSparse(; strict = true)
+
+# supported abelian spaces, all of which contain dual legs
+const abelian_spaces = (
+    "ℤ₂" => TestSetup.VRepℤ₂,
+    "ℤ₃" => TestSetup.VRepℤ₃,
+    "U₁" => TestSetup.VRepU₁,
+)
+# supported fermionic spaces; `TestSetup.VfHubbard` has an `SU2Irrep` factor, so it cannot serve
+const VfRepU₁ = (
+    Vect[FermionNumber](0 => 2, 1 => 2, -1 => 1),
+    Vect[FermionNumber](0 => 1, 1 => 1, -1 => 1)',
+    Vect[FermionNumber](0 => 2, 1 => 1, -1 => 2),
+    Vect[FermionNumber](0 => 1, 1 => 2, -1 => 1)',
+    Vect[FermionNumber](0 => 1, 1 => 1, -1 => 2),
+)
+const fermionic_spaces = ("fℤ₂" => TestSetup.VfRepℤ₂, "fU₁" => VfRepU₁)
+const supported_spaces = (abelian_spaces..., fermionic_spaces...)
+const eltypes = (Float32, Float64, ComplexF32, ComplexF64)
+
+"contract twice -- once through the default path, once block-sparse -- and compare raw data"
+function compare_paths(V, T, pA, pB, pAB, α, β; conjA = false, conjB = false)
+    V1, V2, V3, V4, V5 = V
+    WA = V1 ⊗ V2 ← V3
+    # conjugating exactly one operand dualizes the contracted leg's space requirement
+    WB = (conjA ⊻ conjB) ? (dual(V3) ← V4 ⊗ V5) : (V3 ← V4 ⊗ V5)
+    A = CuTensorMap(randn(T, WA))
+    B = CuTensorMap(randn(T, WB))
+    WC = TO.tensorcontract(space(A), pA, conjA, space(B), pB, conjB, pAB)
+    C0 = CuTensorMap(randn(T, WC))
+
+    ref = copy(C0)
+    TO.tensorcontract!(ref, A, pA, conjA, B, pB, conjB, pAB, α, β, TO.DefaultBackend(), TO.DefaultAllocator())
+    got = copy(C0)
+    TO.tensorcontract!(got, A, pA, conjA, B, pB, conjB, pAB, α, β, bs_strict, TO.DefaultAllocator())
+    return Array(got.data), Array(ref.data)
+end
+
+@testset "blocksparse vs default path: $name, $T" for (name, V) in supported_spaces,
+        T in eltypes
+
+    V1, V2, V3, V4, V5 = V
+    # A: V1 ⊗ V2 ← V3, B: V3 ← V4 ⊗ V5, contract index 3 of A with index 1 of B
+    pA = ((1, 2), (3,))
+    pB = ((1,), (2, 3))
+    for (pAB, label) in (
+            (((1, 2), (3, 4)), "natural"),
+            (((1, 2, 3, 4), ()), "all in codomain"),
+            (((), (1, 2, 3, 4)), "all in domain"),
+            (((2, 1), (4, 3)), "permuted output"),
+            (((3, 1), (2, 4)), "interleaved output"),
+        )
+        for (α, β) in ((one(T), zero(T)), (T(2), zero(T)), (one(T), one(T)), (T(-1.5), T(0.5)))
+            got, ref = compare_paths(V, T, pA, pB, pAB, α, β)
+            @test got ≈ ref
+        end
+    end
+    # α, β genuinely complex
+    if T <: Complex
+        got, ref = compare_paths(V, T, pA, pB, ((1, 2), (3, 4)), T(1 + 2im), T(0.5 - 1im))
+        @test got ≈ ref
+    end
+end
+
+@testset "contracted legs in other positions: $name" for (name, V) in supported_spaces
+    V1, V2, V3, V4, V5 = V
+    T = ComplexF64
+    # contract A's *codomain* index 1 with an index sitting in B's *domain*
+    A = CuTensorMap(randn(T, V1 ⊗ V2 ← V3))
+    B = CuTensorMap(randn(T, V4 ← V1 ⊗ V5))
+    pA, pB, pAB = ((2, 3), (1,)), ((2,), (1, 3)), ((1, 2), (3, 4))
+    WC = TO.tensorcontract(space(A), pA, false, space(B), pB, false, pAB)
+    C0 = CuTensorMap(randn(T, WC))
+    ref, got = copy(C0), copy(C0)
+    TO.tensorcontract!(ref, A, pA, false, B, pB, false, pAB, one(T), zero(T), TO.DefaultBackend(), TO.DefaultAllocator())
+    TO.tensorcontract!(got, A, pA, false, B, pB, false, pAB, one(T), zero(T), bs_strict, TO.DefaultAllocator())
+    @test Array(got.data) ≈ Array(ref.data)
+end
+
+@testset "conjugation: $name, $T" for (name, V) in supported_spaces, T in (Float64, ComplexF64)
+    for (conjA, conjB) in ((true, false), (false, true), (true, true))
+        # a no-op elementwise for real scalars, but it still changes the effective permutation
+        for pAB in (((1, 2), (3, 4)), ((2, 1), (4, 3)), ((3, 1), (2, 4)))
+            got, ref = compare_paths(
+                V, T, ((1, 2), (3,)), ((1,), (2, 3)), pAB, one(T), zero(T); conjA, conjB
+            )
+            @test got ≈ ref
+        end
+    end
+end
+
+# contract over the dual `V4`, so that `blas_contract!` does insert a twist
+@testset "dual contracted leg: $name, $T" for (name, V) in supported_spaces,
+        T in (Float64, ComplexF64)
+
+    V1, V2, V3, V4, V5 = V
+    A = CuTensorMap(randn(T, V1 ⊗ V2 ← V4))
+    B = CuTensorMap(randn(T, V4 ← V3 ⊗ V5))
+    pA, pB = ((1, 2), (3,)), ((1,), (2, 3))
+    for pAB in (((1, 2), (3, 4)), ((2, 1), (4, 3)), ((3, 1), (2, 4)), ((1, 2, 3, 4), ()))
+        WC = TO.tensorcontract(space(A), pA, false, space(B), pB, false, pAB)
+        C0 = CuTensorMap(randn(T, WC))
+        for (α, β) in ((one(T), zero(T)), (T(-1.5), T(0.5)))
+            ref, got = copy(C0), copy(C0)
+            TO.tensorcontract!(ref, A, pA, false, B, pB, false, pAB, α, β, TO.DefaultBackend(), TO.DefaultAllocator())
+            TO.tensorcontract!(got, A, pA, false, B, pB, false, pAB, α, β, bs_strict, TO.DefaultAllocator())
+            @test Array(got.data) ≈ Array(ref.data)
+        end
+    end
+end
+
+@testset "multiple contracted indices: $name" for (name, V) in supported_spaces
+    V1, V2, V3, V4, V5 = V
+    T = Float64
+    A = CuTensorMap(randn(T, V1 ← V2 ⊗ V3))
+    B = CuTensorMap(randn(T, V2 ⊗ V3 ← V4))
+    pA, pB, pAB = ((1,), (2, 3)), ((1, 2), (3,)), ((1,), (2,))
+    WC = TO.tensorcontract(space(A), pA, false, space(B), pB, false, pAB)
+    C0 = CuTensorMap(randn(T, WC))
+    ref, got = copy(C0), copy(C0)
+    TO.tensorcontract!(ref, A, pA, false, B, pB, false, pAB, one(T), zero(T), TO.DefaultBackend(), TO.DefaultAllocator())
+    TO.tensorcontract!(got, A, pA, false, B, pB, false, pAB, one(T), zero(T), bs_strict, TO.DefaultAllocator())
+    @test Array(got.data) ≈ Array(ref.data)
+    # and with the contracted indices in the other order, which forces different mode labels
+    pA2, pB2 = ((1,), (3, 2)), ((2, 1), (3,))
+    ref2, got2 = copy(C0), copy(C0)
+    TO.tensorcontract!(ref2, A, pA2, false, B, pB2, false, pAB, one(T), zero(T), TO.DefaultBackend(), TO.DefaultAllocator())
+    TO.tensorcontract!(got2, A, pA2, false, B, pB2, false, pAB, one(T), zero(T), bs_strict, TO.DefaultAllocator())
+    @test Array(got2.data) ≈ Array(ref2.data)
+end
+
+@testset "@tensor integration: $name" for (name, V) in (
+        "U₁" => TestSetup.VRepU₁, "fℤ₂" => TestSetup.VfRepℤ₂,
+    )
+    V1, V2, V3, V4, V5 = V
+    A = CuTensorMap(randn(ComplexF64, V1 ⊗ V2 ← V3))
+    B = CuTensorMap(randn(ComplexF64, V3 ← V4 ⊗ V5))
+    # `@tensor` is the only route supplying `α = One()`, `β = Zero()`/`One()`
+    @tensor ref[a, b, d, e] := A[a, b, c] * B[c, d, e]
+    @tensor backend = bs got[a, b, d, e] := A[a, b, c] * B[c, d, e]
+    @test Array(got.data) ≈ Array(ref.data)
+    # `+=` gives `β = One()`, which takes the pre-scaling path
+    @tensor ref[a, b, d, e] += A[a, b, c] * B[c, d, e]
+    @tensor backend = bs got[a, b, d, e] += A[a, b, c] * B[c, d, e]
+    @test Array(got.data) ≈ Array(ref.data)
+    # an output permutation, so that the result correction is non-trivial for fermions
+    @tensor ref2[b, a, e, d] := A[a, b, c] * B[c, d, e]
+    @tensor backend = bs got2[b, a, e, d] := A[a, b, c] * B[c, d, e]
+    @test Array(got2.data) ≈ Array(ref2.data)
+end
+
+@testset "shared operand: $name" for (name, V) in supported_spaces
+    # `A === B` is legal, so the sign correction must not scale a shared operand in place
+    V1, V2, V3, V4, V5 = V
+    T = ComplexF64
+    A = CuTensorMap(randn(T, V3 ← V3 ⊗ V3))
+    pA, pB = ((1, 2), (3,)), ((1,), (2, 3))
+    for pAB in (((1, 2), (3, 4)), ((2, 1), (4, 3)))
+        WC = TO.tensorcontract(space(A), pA, false, space(A), pB, false, pAB)
+        C0 = CuTensorMap(randn(T, WC))
+        ref, got = copy(C0), copy(C0)
+        Adata = Array(A.data)
+        TO.tensorcontract!(ref, A, pA, false, A, pB, false, pAB, one(T), zero(T), TO.DefaultBackend(), TO.DefaultAllocator())
+        TO.tensorcontract!(got, A, pA, false, A, pB, false, pAB, one(T), zero(T), bs_strict, TO.DefaultAllocator())
+        @test Array(got.data) ≈ Array(ref.data)
+        @test Array(A.data) == Adata     # ... and the operand is left untouched
+    end
+end
+
+@testset "fallback is silent and correct" begin
+    # non-abelian and `Trivial` sectors are unsupported, but must still give the right answer
+    for V in (TestSetup.VRepSU₂, TestSetup.VfHubbard, TestSetup.Vtr)
+        V1, V2, V3, V4, V5 = V
+        T = ComplexF64
+        A = CuTensorMap(randn(T, V1 ⊗ V2 ← V3))
+        B = CuTensorMap(randn(T, V3 ← V4 ⊗ V5))
+        pA, pB, pAB = ((1, 2), (3,)), ((1,), (2, 3)), ((1, 2), (3, 4))
+        WC = TO.tensorcontract(space(A), pA, false, space(B), pB, false, pAB)
+        C0 = CuTensorMap(randn(T, WC))
+        ref, got = copy(C0), copy(C0)
+        TO.tensorcontract!(ref, A, pA, false, B, pB, false, pAB, one(T), zero(T), TO.DefaultBackend(), TO.DefaultAllocator())
+        TO.tensorcontract!(got, A, pA, false, B, pB, false, pAB, one(T), zero(T), bs, TO.DefaultAllocator())
+        @test Array(got.data) ≈ Array(ref.data)
+        @test !blocksparse_supported(C0, A, pA, false, B, pB, false, pAB)
+        # ... and `strict` complains instead
+        @test_throws BlockSparseUnsupported TO.tensorcontract!(
+            copy(C0), A, pA, false, B, pB, false, pAB,
+            one(T), zero(T), bs_strict, TO.DefaultAllocator()
+        )
+    end
+end
+
+@testset "unsupported eltype falls back" begin
+    V = TestSetup.VRepℤ₂
+    V1, V2, V3, V4, V5 = V
+    T = ComplexF16
+    A = CuTensorMap(randn(T, V1 ⊗ V2 ← V3))
+    B = CuTensorMap(randn(T, V3 ← V4 ⊗ V5))
+    pA, pB, pAB = ((1, 2), (3,)), ((1,), (2, 3)), ((1, 2), (3, 4))
+    WC = TO.tensorcontract(space(A), pA, false, space(B), pB, false, pAB)
+    C0 = CuTensorMap(randn(T, WC))
+    @test !blocksparse_supported(C0, A, pA, false, B, pB, false, pAB)
+    @test occursin("scalar type", blocksparse_reason(C0, A, pA, false, B, pB, false, pAB))
+end
+
+@testset "a failed contraction does not corrupt the output" begin
+    # a complex `α` throws before cuTENSOR touches anything, so the output correction must not
+    # be left half-applied -- for `β = 0` that would negate every block whose sign is -1
+    V1, V2, V3, V4, V5 = TestSetup.VfRepℤ₂
+    T = Float64
+    A = CuTensorMap(randn(T, V1 ⊗ V2 ← V3))
+    B = CuTensorMap(randn(T, V3 ← V4 ⊗ V5))
+    pA, pB, pAB = ((1, 2), (3,)), ((1,), (2, 3)), ((2, 1), (4, 3))   # non-trivial `signs.C`
+    WC = TO.tensorcontract(space(A), pA, false, space(B), pB, false, pAB)
+    C = CuTensorMap(randn(T, WC))
+    for β in (zero(T), one(T))
+        before = Array(C.data)
+        @test_throws InexactError TO.tensorcontract!(
+            C, A, pA, false, B, pB, false, pAB, T(1) + 2im, β, bs_strict,
+            TO.DefaultAllocator()
+        )
+        @test Array(C.data) == before
+    end
+end
+
+@testset "a plan carries the sign correction for every conjugation" begin
+    # `_signs_index` must agree with the order `_create_plan` derives the combinations in
+    V1, V2, V3, V4, V5 = TestSetup.VfRepℤ₂
+    T = ComplexF64
+    pA, pB, pAB = ((1, 2), (3,)), ((1,), (2, 3)), ((2, 1), (4, 3))
+    WA, WB = V1 ⊗ V2 ← V3, V3 ← V4 ⊗ V5
+    WC = TO.tensorcontract(WA, pA, false, WB, pB, false, pAB)
+    plan = plan_contract(T, WC, WA, pA, WB, pB, pAB)
+    @test length(plan.signs) == 4
+    for conjA in (false, true), conjB in (false, true)
+        expected = bs_signs(WC, WA, pA, conjA, WB, pB, conjB, pAB)
+        got = plan.signs[_signs_index(conjA, conjB)]
+        @test (got.A, got.B, got.C) == (expected.A, expected.B, expected.C)
+    end
+    # a bosonic plan carries four trivial corrections, i.e. costs nothing to have derived
+    Vb = TestSetup.VRepU₁
+    WAb, WBb = Vb[1] ⊗ Vb[2] ← Vb[3], Vb[3] ← Vb[4] ⊗ Vb[5]
+    WCb = TO.tensorcontract(WAb, pA, false, WBb, pB, false, pAB)
+    planb = plan_contract(T, WCb, WAb, pA, WBb, pB, pAB)
+    @test all(TensorKit.istrivial, planb.signs)
+end
+
+@testset "plan_contract rejects unsupported sectors" begin
+    # a plan never consults `blocksparse_reason`, so the sector gate is applied when it is built
+    V1, V2, V3, V4, V5 = TestSetup.VfHubbard
+    T = ComplexF64
+    A = CuTensorMap(randn(T, V1 ⊗ V2 ← V3))
+    B = CuTensorMap(randn(T, V3 ← V4 ⊗ V5))
+    pA, pB, pAB = ((1, 2), (3,)), ((1,), (2, 3)), ((1, 2), (3, 4))
+    WC = TO.tensorcontract(space(A), pA, false, space(B), pB, false, pAB)
+    C = CuTensorMap(randn(T, WC))
+    @test_throws BlockSparseUnsupported plan_contract(C, A, pA, B, pB, pAB)
+
+    # a plan bypasses `blocksparse_reason`, so it must refuse an aliased output itself
+    V = TestSetup.VfRepℤ₂[3]
+    A2 = CuTensorMap(randn(T, V ← V ⊗ V))
+    WC2 = TO.tensorcontract(space(A2), pA, false, space(A2), pB, false, pAB)
+    C2 = CuTensorMap(randn(T, WC2))
+    plan = plan_contract(C2, A2, pA, A2, pB, pAB)
+    @test isnothing(check_plan(plan, C2, A2, pA, A2, pB, pAB))
+    @test_throws ArgumentError check_plan(plan, A2, A2, pA, A2, pB, pAB)
+end
+
+@testset "plan reuse" begin
+    V = TestSetup.VRepU₁
+    V1, V2, V3, V4, V5 = V
+    T = Float64
+    pA, pB, pAB = ((1, 2), (3,)), ((1,), (2, 3)), ((1, 2), (3, 4))
+    A = CuTensorMap(randn(T, V1 ⊗ V2 ← V3))
+    B = CuTensorMap(randn(T, V3 ← V4 ⊗ V5))
+    WC = TO.tensorcontract(space(A), pA, false, space(B), pB, false, pAB)
+    C = CuTensorMap(randn(T, WC))
+
+    empty!(PLAN_CACHE)
+    TO.tensorcontract!(C, A, pA, false, B, pB, false, pAB, one(T), zero(T), bs_strict, TO.DefaultAllocator())
+    @test length(PLAN_CACHE) == 1
+    # same spaces, different data: still one plan
+    A2 = CuTensorMap(randn(T, V1 ⊗ V2 ← V3))
+    TO.tensorcontract!(C, A2, pA, false, B, pB, false, pAB, one(T), zero(T), bs_strict, TO.DefaultAllocator())
+    @test length(PLAN_CACHE) == 1
+
+    # an explicitly supplied plan gives identical results
+    plan = plan_contract(C, A, pA, B, pB, pAB)
+    ref, got = copy(C), copy(C)
+    TO.tensorcontract!(ref, A, pA, false, B, pB, false, pAB, T(1.5), T(-0.25), bs_strict, TO.DefaultAllocator())
+    TO.tensorcontract!(got, A, pA, false, B, pB, false, pAB, T(1.5), T(-0.25), plan, TO.DefaultAllocator())
+    @test Array(got.data) ≈ Array(ref.data)
+    # the data-free form agrees
+    plan2 = plan_contract(T, space(C), space(A), pA, space(B), pB, pAB)
+    @test plan2 === plan
+
+    # reusing a plan for a different (but individually valid) contraction is caught
+    Vs = Vect[U1Irrep](0 => 1, 1 => 1, -1 => 1)
+    A3 = CuTensorMap(randn(T, Vs ⊗ Vs ← Vs))
+    B3 = CuTensorMap(randn(T, Vs ← Vs ⊗ Vs))
+    WC3 = TO.tensorcontract(space(A3), pA, false, space(B3), pB, false, pAB)
+    C3 = CuTensorMap(randn(T, WC3))
+    @test_throws ArgumentError TO.tensorcontract!(
+        C3, A3, pA, false, B3, pB, false, pAB,
+        one(T), zero(T), plan, TO.DefaultAllocator()
+    )
+
+    # the cache is registered with TensorKit's cache registry
+    empty_globalcaches!()
+    @test isempty(PLAN_CACHE)
+    TO.tensorcontract!(C, A, pA, false, B, pB, false, pAB, one(T), zero(T), bs_strict, TO.DefaultAllocator())
+    @test length(PLAN_CACHE) == 1
+end
+
+@testset "non-trivial workspace" begin
+    # large enough that cuTENSOR asks for a real workspace, which the wrapper's argtype bug broke
+    V = Vect[U1Irrep](-1 => 24, 0 => 32, 1 => 24)
+    T = Float64
+    pA, pB, pAB = ((1, 2), (3,)), ((1,), (2, 3)), ((1, 2), (3, 4))
+    A = CuTensorMap(randn(T, V ⊗ V ← V))
+    B = CuTensorMap(randn(T, V ← V ⊗ V))
+    WC = TO.tensorcontract(space(A), pA, false, space(B), pB, false, pAB)
+    C = CuTensorMap(randn(T, WC))
+    plan = plan_contract(C, A, pA, B, pB, pAB)
+    @test plan.workspacesize > 0
+    ref, got = copy(C), copy(C)
+    TO.tensorcontract!(ref, A, pA, false, B, pB, false, pAB, one(T), zero(T), TO.DefaultBackend(), TO.DefaultAllocator())
+    TO.tensorcontract!(got, A, pA, false, B, pB, false, pAB, one(T), zero(T), bs_strict, TO.DefaultAllocator())
+    @test Array(got.data) ≈ Array(ref.data)
+end

--- a/test/other/blocksparse.jl
+++ b/test/other/blocksparse.jl
@@ -1,0 +1,469 @@
+using Test, TestExtras
+using TensorOperations: TensorOperations as TO
+using TensorKit
+using TensorKit: blocksparsestructure,
+    nmodes, nblocks, BlockSparseUnsupported, subblockstructure, fusiontrees,
+    blocksparse_contract_signs, BlockSparseSigns, istrivial, subblock,
+    _blocksparse_operand_signs, _blocksparse_output_signs, _scale_subblocks!,
+    sectorscalartype
+
+@isdefined(TestSetup) || include("../setup.jl")
+using .TestSetup
+
+# Host-side validation of the block-sparse description of a `HomSpace`: the sector-ordering,
+# dual-space and stride reasoning the cuTENSOR backend relies on, pinned down without a GPU.
+
+"per-mode cumulative section offsets, so section `k` of mode `i` spans `off[i][k]+1:off[i][k+1]`"
+function section_offsets(s)
+    N = nmodes(s)
+    offsets = Vector{Vector{Int}}(undef, N)
+    k = 0
+    for i in 1:N
+        cum = Int[0]
+        for j in 1:s.numsections[i]
+            push!(cum, cum[end] + s.extent[k + j])
+        end
+        k += s.numsections[i]
+        offsets[i] = cum
+    end
+    return offsets
+end
+
+"read block `b` out of the flat data vector using only `(extent, strides, offset)`"
+function read_block(t, s, b)
+    N = nmodes(s)
+    coords = view(s.coordinates, :, b)
+    strides = view(s.strides, :, b)
+    secoff = section_offsets(s)
+    sz = ntuple(i -> secoff[i][coords[i] + 2] - secoff[i][coords[i] + 1], N)
+    blk = Array{scalartype(t)}(undef, sz)
+    for idx in CartesianIndices(sz)
+        lin = s.offsets[b] + 1 + sum(i -> (idx[i] - 1) * strides[i], 1:N; init = 0)
+        blk[idx] = t.data[lin]
+    end
+    return blk
+end
+
+"the dense index ranges block `b` occupies"
+function block_ranges(s, b)
+    N = nmodes(s)
+    secoff = section_offsets(s)
+    return ntuple(N) do i
+        c = s.coordinates[i, b]
+        return (secoff[i][c + 1] + 1):secoff[i][c + 2]
+    end
+end
+
+const abelian_spaces = (
+    "ℤ₂" => TestSetup.VRepℤ₂,
+    "ℤ₃" => TestSetup.VRepℤ₃,
+    "U₁" => TestSetup.VRepU₁,
+)
+
+# abelian fermionic spaces; `TestSetup.VfHubbard` has an `SU2Irrep` factor, so it cannot serve
+const VfRepU₁ = (
+    Vect[FermionNumber](0 => 2, 1 => 2, -1 => 1),
+    Vect[FermionNumber](0 => 1, 1 => 1, -1 => 1)',
+    Vect[FermionNumber](0 => 2, 1 => 1, -1 => 2),
+    Vect[FermionNumber](0 => 1, 1 => 2, -1 => 1)',
+    Vect[FermionNumber](0 => 1, 1 => 1, -1 => 2),
+)
+const fermionic_spaces = ("fℤ₂" => TestSetup.VfRepℤ₂, "fU₁" => VfRepU₁)
+
+@testset "blocksparse_compatible trait" begin
+    for I in (
+            Z2Irrep, Z3Irrep, Z4Irrep, ZNIrrep{7}, U1Irrep, Z3Irrep ⊠ Z4Irrep,
+            Z2Irrep ⊠ U1Irrep,
+        )
+        @test blocksparse_compatible(I)
+    end
+    # fermionic sectors qualify through the per-block sign correction
+    for I in (FermionParity, FermionNumber, FermionParity ⊠ U1Irrep)
+        @test blocksparse_compatible(I)
+        @test BraidingStyle(I) isa Fermionic
+    end
+    # unique fusion is NOT sufficient: anyonic R-symbols are phases rather than signs
+    for I in (Z3Element{1}, ZNElement{5, 2}, Z4Element{2})
+        @test !blocksparse_compatible(I)
+        @test FusionStyle(I) isa UniqueFusion  # ... and yet they do have unique fusion
+    end
+    for I in (
+            Trivial, SU2Irrep, CU1Irrep, FibonacciAnyon, A4Irrep, IsingAnyon,
+            FermionSpin, FermionParity ⊠ SU2Irrep ⊠ U1Irrep,
+        )
+        @test !blocksparse_compatible(I)
+    end
+end
+
+@testset "layout for $name" for (name, V) in (abelian_spaces..., fermionic_spaces...)
+    V1, V2, V3, V4, V5 = V
+    homspaces = (
+        V1 ← V2,
+        V1 ⊗ V2 ← V3,
+        V1 ⊗ V2 ← V3 ⊗ V4,
+        V1 ⊗ V2 ⊗ V3 ← V4 ⊗ V5,
+        V1 ⊗ V2 ← one(V1),          # N₂ == 0
+        one(V1) ← V4 ⊗ V5,          # N₁ == 0
+    )
+    for W in homspaces
+        s = blocksparsestructure(W)
+
+        @testset "$W" begin
+            # the constraint block-sparse libraries impose: one permutation -- here the
+            # identity -- sorts every block's strides ascending
+            for (_, st, _) in values(subblockstructure(W))
+                @test issorted(st)
+            end
+
+            # one block per fusion tree pair, in that order
+            @test nblocks(s) == length(fusiontrees(W))
+            @test nmodes(s) == numind(W)
+            @test length(s.numsections) == numind(W)
+            @test length(s.extent) == sum(s.numsections)
+            @test size(s.coordinates) == (nmodes(s), nblocks(s))
+            @test size(s.strides) == (nmodes(s), nblocks(s))
+
+            # sections of a mode tile that mode's dimension, even though `W[i]` duals the
+            # domain factors while the section labels do not
+            secoff = section_offsets(s)
+            for i in 1:numind(W)
+                @test last(secoff[i]) == dim(W[i])
+            end
+
+            # coordinates are zero-based and in range
+            for b in 1:nblocks(s), i in 1:nmodes(s)
+                c = s.coordinates[i, b]
+                @test 0 <= c < s.numsections[i]
+            end
+
+            # strides and offsets are `subblockstructure`'s, verbatim
+            substr = collect(values(subblockstructure(W)))
+            for b in 1:nblocks(s)
+                _, st, offset = substr[b]
+                @test s.offsets[b] == offset
+                @test Tuple(view(s.strides, :, b)) == st
+            end
+
+            # blocks exactly tile the flat data vector
+            @test sum(1:nblocks(s); init = 0) do b
+                prod(length, block_ranges(s, b))
+            end == dim(W)
+        end
+    end
+end
+
+@testset "blocks equal dense slices for $name" for (name, V) in abelian_spaces
+    V1, V2, V3, V4, V5 = V
+    hasfusiontensor(sectortype(V1)) || continue
+    for W in (V1 ⊗ V2 ← V3, V1 ⊗ V2 ← V3 ⊗ V4, V1 ⊗ V2 ⊗ V3 ← V4 ⊗ V5)
+        for T in (Float64, ComplexF64)
+            t = randn(T, W)
+            s = blocksparsestructure(W)
+            A = convert(Array, t)
+            covered = falses(size(A))
+            @testset "$T $W" begin
+                for b in 1:nblocks(s)
+                    r = block_ranges(s, b)
+                    # the load-bearing claim: a subblock addressed only via
+                    # (extent, strides, offset) is the corresponding dense slice
+                    @test read_block(t, s, b) ≈ A[r...]
+                    @test !any(view(covered, r...))   # blocks do not overlap
+                    covered[r...] .= true
+                end
+                # everything the blocks do not cover is zero by charge conservation
+                @test all(iszero, A[.!covered])
+            end
+        end
+    end
+end
+
+@testset "fused scratch write for $name, $T" for (name, V) in (
+            abelian_spaces..., fermionic_spaces...,
+        ), T in (Float64, ComplexF64)
+
+    # drive the extension's fused scratch write on the host, where a bug shows up without a GPU
+    V1, V2, V3, V4, V5 = V
+    for W in (V1 ⊗ V2 ← V3, V1 ⊗ V2 ← V3 ⊗ V4, V1 ⊗ V2 ⊗ V3 ← V4 ⊗ V5)
+        t = randn(T, W)
+        n = length(fusiontrees(W))
+        # unit scalars, as the real thing gets: ±1 for fermions, phases in the complex case
+        signs = T <: Complex ? cis.(2π .* rand(n)) : rand((-1.0, 1.0), n)
+        for doconj in (false, true)
+            # NaN-filled, so a subblock the fused write skips cannot go unnoticed
+            dst = similar(t)
+            fill!(dst.data, T(NaN))
+            _scale_subblocks!(dst, t, signs, doconj)
+
+            # the two-pass reference the extension used to run
+            ref = copy(t)
+            doconj && (ref.data .= conj.(t.data))
+            _scale_subblocks!(ref, signs)
+
+            @test !any(isnan, dst.data)
+            @test dst.data ≈ ref.data
+        end
+    end
+end
+
+# Per-block sign correction
+# -------------------------
+# Reimplement on the host what the extension does -- scale the operand blocks, contract
+# block-wise, scale the result blocks -- and compare against the default path.
+
+"total extent of each mode, i.e. the shape of the dense array the blocks tile"
+function dense_size(W)
+    s = blocksparsestructure(W)
+    secoff = section_offsets(s)
+    return ntuple(i -> last(secoff[i]), nmodes(s))
+end
+
+"embed the stored blocks of `t` into a dense array; whatever no block covers stays zero"
+function dense_embedding(t)
+    s = blocksparsestructure(space(t))
+    d = zeros(scalartype(t), dense_size(space(t)))
+    for b in 1:nblocks(s)
+        d[block_ranges(s, b)...] = read_block(t, s, b)
+    end
+    return d
+end
+
+"the inverse: read the stored blocks of a `WC`-shaped tensor back out of a dense array"
+function from_dense_embedding(d, WC, ::Type{T}) where {T}
+    C = zeros(T, WC)
+    s = blocksparsestructure(WC)
+    trees = collect(fusiontrees(WC))
+    for b in 1:nblocks(s)
+        copyto!(subblock(C, trees[b]), d[block_ranges(s, b)...])
+    end
+    return C
+end
+
+"""
+    naive_blockwise(WC, A, pA, conjA, B, pB, conjB, pAB, T)
+
+What a block-sparse kernel computes: the raw block data contracted with plain
+tensor-contraction semantics, with no fusion tree transformation.
+
+Realized by embedding the stored blocks densely and contracting *once*, rather than by matching
+blocks pairwise: that avoids reimplementing cuTENSOR's block matching, and it only gives the
+right answer if the dense axes of the contracted modes line up, so a violation of the
+section-index invariant surfaces as a `DimensionMismatch` rather than as a wrong number.
+"""
+function naive_blockwise(WC, A, pA, conjA, B, pB, conjB, pAB, ::Type{T}) where {T}
+    d = zeros(T, dense_size(WC))
+    TO.tensorcontract!(
+        d, dense_embedding(A), pA, conjA, dense_embedding(B), pB, conjB, pAB, true, false
+    )
+    return from_dense_embedding(d, WC, T)
+end
+
+# drive the shipping helper, so that a bug in it is caught here and not only on a GPU
+scale_blocks!(t, ::Nothing) = t
+scale_blocks!(t, signs) = _scale_subblocks!(t, signs)
+
+"""
+`tensorcontract!` via the block-sparse route, with the sign correction applied. `α`/`β` are
+applied by a plain `add!` rather than by the extension's pre/post-scaling trick, which is
+covered on the GPU side instead.
+"""
+function signed_blockwise(C0, A, pA, conjA, B, pB, conjB, pAB, α, β, ::Type{T}, signs) where {T}
+    A′ = scale_blocks!(copy(A), signs.A)
+    B′ = scale_blocks!(copy(B), signs.B)
+    D = naive_blockwise(space(C0), A′, pA, conjA, B′, pB, conjB, pAB, T)
+    scale_blocks!(D, signs.C)
+    return add!(scale!(copy(C0), β), D, α)
+end
+
+"""
+The contraction geometries the sign derivation has to cover. Conjugating *exactly one* operand
+dualizes the composability requirement on the contracted legs, so both variants are listed and
+the sweep skips whichever combinations do not typecheck.
+"""
+function sign_cases(V)
+    V1, V2, V3, V4, V5 = V
+    return (
+        # contracted leg non-dual, so `blas_contract!` inserts no twist
+        ("non-dual contracted leg", V1 ⊗ V2 ← V3, V3 ← V4 ⊗ V5, ((1, 2), (3,)), ((1,), (2, 3))),
+        ("non-dual contracted leg, dualized", V1 ⊗ V2 ← V3, dual(V3) ← V4 ⊗ V5, ((1, 2), (3,)), ((1,), (2, 3))),
+        # ... and dual (`V2` and `V4` are dual in every test space), so it does
+        ("dual contracted leg", V1 ⊗ V2 ← V4, V4 ← V3 ⊗ V5, ((1, 2), (3,)), ((1,), (2, 3))),
+        ("dual contracted leg, dualized", V1 ⊗ V2 ← V4, dual(V4) ← V3 ⊗ V5, ((1, 2), (3,)), ((1,), (2, 3))),
+        # contracted leg in `A`'s codomain and in `B`'s domain
+        ("contracted legs off-diagonal", V1 ⊗ V2 ← V3, V4 ← V1 ⊗ V5, ((2, 3), (1,)), ((2,), (1, 3))),
+        ("contracted legs off-diagonal, dualized", V1 ⊗ V2 ← V3, V4 ← dual(V1) ⊗ V5, ((2, 3), (1,)), ((2,), (1, 3))),
+        ("two contracted legs", V1 ← V2 ⊗ V3, V2 ⊗ V3 ← V4, ((1,), (2, 3)), ((1, 2), (3,))),
+        ("two contracted legs, dualized", V1 ← V2 ⊗ V3, dual(V2) ⊗ dual(V3) ← V4, ((1,), (2, 3)), ((1, 2), (3,))),
+        ("two contracted legs, swapped", V1 ← V2 ⊗ V3, V2 ⊗ V3 ← V4, ((1,), (3, 2)), ((2, 1), (3,))),
+    )
+end
+
+"output partitions to sweep for an `n`-index result; the sign only shows up under these"
+function sign_partitions(n)
+    return n == 4 ?
+        (
+            ((1, 2), (3, 4)), ((1, 2, 3, 4), ()), ((), (1, 2, 3, 4)), ((2, 1), (4, 3)),
+            ((3, 1), (2, 4)), ((4, 3, 2, 1), ()),
+        ) :
+        (((1,), (2,)), ((1, 2), ()), ((2, 1), ()), ((), (2, 1)))
+end
+
+"the output space of a contraction, or `nothing` if this combination is not well-formed"
+function contract_space(WA, pA, conjA, WB, pB, conjB, pAB)
+    return try
+        TO.tensorcontract(WA, pA, conjA, WB, pB, conjB, pAB)
+    catch e
+        e isa Union{SpaceMismatch, ArgumentError} || rethrow()
+        nothing
+    end
+end
+
+const conjugations = ((false, false), (true, false), (false, true), (true, true))
+
+@testset "signs are trivial for $name" for (name, V) in abelian_spaces
+    for (_, WA, WB, pA, pB) in sign_cases(V)
+        for pAB in sign_partitions(length(pA[1]) + length(pB[2])),
+                (conjA, conjB) in conjugations
+
+            WC = contract_space(WA, pA, conjA, WB, pB, conjB, pAB)
+            isnothing(WC) && continue
+            # bosonic sectors need no correction at all, whatever the permutations
+            @test istrivial(
+                blocksparse_contract_signs(WC, WA, pA, conjA, WB, pB, conjB, pAB)
+            )
+        end
+    end
+end
+
+@testset "sign correction for $name, $T" for (name, V) in fermionic_spaces,
+        T in (Float64, ComplexF64)
+
+    covered = Dict(c => 0 for c in conjugations)
+    for (case, WA, WB, pA, pB) in sign_cases(V)
+        @testset "$case" begin
+            for pAB in sign_partitions(length(pA[1]) + length(pB[2])),
+                    (conjA, conjB) in conjugations
+
+                WC = contract_space(WA, pA, conjA, WB, pB, conjB, pAB)
+                isnothing(WC) && continue
+                covered[(conjA, conjB)] += 1
+                signs = blocksparse_contract_signs(WC, WA, pA, conjA, WB, pB, conjB, pAB)
+                A, B, C0 = randn(T, WA), randn(T, WB), randn(T, WC)
+                for (α, β) in ((one(T), zero(T)), (T(-1.5), T(0.5)))
+                    ref = TO.tensorcontract!(
+                        copy(C0), A, pA, conjA, B, pB, conjB, pAB, α, β,
+                        TO.DefaultBackend(), TO.DefaultAllocator()
+                    )
+                    got = signed_blockwise(
+                        C0, A, pA, conjA, B, pB, conjB, pAB, α, β, T, signs
+                    )
+                    @test got.data ≈ ref.data
+                end
+            end
+        end
+    end
+    # not all `(conjA, conjB)` combinations compose, so guard against a silently skipped one
+    @testset "coverage" begin
+        for c in conjugations
+            @test covered[c] > 0
+        end
+    end
+end
+
+@testset "every sign factor is load-bearing" begin
+    # guards against a vacuous test above: with any factor dropped the results must disagree
+    V = TestSetup.VfRepℤ₂
+    T = ComplexF64
+    Tc = sectorscalartype(sectortype(V[1]))
+    drop_none(WC, WA, pA, cA, WB, pB, cB, pAB) =
+        blocksparse_contract_signs(WC, WA, pA, cA, WB, pB, cB, pAB)
+    drop_all(WC, WA, pA, cA, WB, pB, cB, pAB) =
+        BlockSparseSigns{Tc}(nothing, nothing, nothing)
+    drop_twist(WC, WA, pA, cA, WB, pB, cB, pAB) = BlockSparseSigns{Tc}(
+        _blocksparse_operand_signs(Tc, WA, pA, cA, false),
+        _blocksparse_operand_signs(Tc, WB, pB, cB, false),
+        _blocksparse_output_signs(Tc, WC, length(pA[1]), pAB)
+    )
+    drop_output(WC, WA, pA, cA, WB, pB, cB, pAB) = BlockSparseSigns{Tc}(
+        _blocksparse_operand_signs(Tc, WA, pA, cA, true),
+        _blocksparse_operand_signs(Tc, WB, pB, cB, false),
+        nothing
+    )
+
+    for variant in (drop_all, drop_twist, drop_output)
+        agree = total = 0
+        for (_, WA, WB, pA, pB) in sign_cases(V)
+            for pAB in sign_partitions(length(pA[1]) + length(pB[2])),
+                    (conjA, conjB) in ((false, false), (true, false))
+
+                WC = contract_space(WA, pA, conjA, WB, pB, conjB, pAB)
+                isnothing(WC) && continue
+                A, B, C0 = randn(T, WA), randn(T, WB), randn(T, WC)
+                ref = TO.tensorcontract!(
+                    copy(C0), A, pA, conjA, B, pB, conjB, pAB, one(T), zero(T),
+                    TO.DefaultBackend(), TO.DefaultAllocator()
+                )
+                got = signed_blockwise(
+                    C0, A, pA, conjA, B, pB, conjB, pAB, one(T), zero(T), T,
+                    variant(WC, WA, pA, conjA, WB, pB, conjB, pAB)
+                )
+                total += 1
+                agree += got.data ≈ ref.data
+            end
+        end
+        @test total > 0
+        @test agree < total
+    end
+end
+
+@testset "repartition alone needs a correction" begin
+    # a natural index *order* is not enough: bending a leg between codomain and domain is not
+    # free for fermions, so `pAB = ((1,2,3,4),())` carries a correction despite permuting nothing
+    V1, V2, V3, V4, V5 = TestSetup.VfRepℤ₂
+    WA, WB, pA, pB = V1 ⊗ V2 ← V3, V3 ← V4 ⊗ V5, ((1, 2), (3,)), ((1,), (2, 3))
+    identity_order = ((1, 2, 3, 4), ())
+    @test TO.linearize(identity_order) == (1, 2, 3, 4)   # ... it really is the identity
+    WC = TO.tensorcontract(WA, pA, false, WB, pB, false, identity_order)
+    signs = blocksparse_contract_signs(WC, WA, pA, false, WB, pB, false, identity_order)
+    @test !isnothing(signs.C)
+    # ... whereas the partition the contraction produces naturally does not
+    natural = ((1, 2), (3, 4))
+    WC′ = TO.tensorcontract(WA, pA, false, WB, pB, false, natural)
+    @test isnothing(blocksparse_contract_signs(WC′, WA, pA, false, WB, pB, false, natural).C)
+end
+
+@testset "sign derivation is a pure function of the geometry" begin
+    # derived once per plan rather than per call, so it must be deterministic and must depend
+    # on the conjugation flags -- which is why a plan carries all four combinations
+    V1, V2, V3, V4, V5 = TestSetup.VfRepℤ₂
+    WA, WB = V1 ⊗ V2 ← V3, V3 ← V4 ⊗ V5
+    pA, pB, pAB = ((1, 2), (3,)), ((1,), (2, 3)), ((2, 1), (4, 3))
+    WC = TO.tensorcontract(WA, pA, false, WB, pB, false, pAB)
+    s1 = blocksparse_contract_signs(WC, WA, pA, false, WB, pB, false, pAB)
+    @test !istrivial(s1)                  # this geometry does need a correction
+    s1′ = blocksparse_contract_signs(WC, WA, pA, false, WB, pB, false, pAB)
+    @test (s1′.A, s1′.B, s1′.C) == (s1.A, s1.B, s1.C)
+    s2 = blocksparse_contract_signs(WC, WA, pA, true, WB, pB, false, pAB)
+    @test s2.A != s1.A
+end
+
+@testset "unsupported spaces" begin
+    V = Vect[Z2Irrep](0 => 2, 1 => 2)
+    # no non-zero blocks: incompatible charge sectors
+    W = Vect[Z2Irrep](0 => 1) ← Vect[Z2Irrep](1 => 1)
+    @test_throws BlockSparseUnsupported blocksparsestructure(W)
+    # a scalar has no modes
+    @test_throws BlockSparseUnsupported blocksparsestructure(one(V) ← one(V))
+end
+
+@testset "caching" begin
+    V = Vect[U1Irrep](0 => 2, 1 => 2, -1 => 1)
+    W = V ⊗ V ← V
+    s1 = blocksparsestructure(W)
+    s2 = blocksparsestructure(W)
+    @test s1 === s2                       # cached per HomSpace
+    empty_globalcaches!()
+    s3 = blocksparsestructure(W)
+    @test s3 !== s1
+    @test s3.offsets == s1.offsets        # ... but identical content
+    @test s3.strides == s1.strides
+end


### PR DESCRIPTION
This is an initial implementation of calling into cuTENSOR's blocksparse contraction, which should be able to speed up our `UniqueFusion` code. There is still a bit of annoyance for supporting conjugation flags, and non-trivial F or R symbol coefficients, where this has to be handled in pre/postprocessing, but it seems at least from my initial local benchmarks that this is still competitive and outperforms our naive implementation.

Still requires quite a bit of cleanup, and there is one design question that I am still unsure about, which considers whether or not we should keep the "BlockSparseStructure" as something cuTENSOR specific moved into the extension, or as a generic thing backends can hook into.
On the one hand nothing about that is cuTENSOR specific, and there is a case to be made that we could even on CPU do this strategy which merges permutation and multiplication, (maybe someone has a RUST library somewhere that he is working on 😉) but unfortunately the annoying thing is that cuTENSOR is really particular about what integer types have to be where.

Anyways, I'll keep working on this but already wanted to open this up to let everyone know this is in progress.