### PR TITLE
Add support for all kwargs in `permute` and `transpose` chain rules

### DIFF
--- a/ext/TensorKitChainRulesCoreExt/linalg.jl
+++ b/ext/TensorKitChainRulesCoreExt/linalg.jl
@@ -60,24 +60,24 @@ function ChainRulesCore.rrule(::typeof(⊗), A::AbstractTensorMap, B::AbstractTe
 end
 
 function ChainRulesCore.rrule(
-        ::typeof(permute), tsrc::AbstractTensorMap, p::Index2Tuple; copy::Bool = false
+        ::typeof(permute), tsrc::AbstractTensorMap, p::Index2Tuple; copy::Bool = false, kwargs...
     )
     function permute_pullback(Δtdst)
         invp = TensorKit._canonicalize(TupleTools.invperm(linearize(p)), tsrc)
-        return NoTangent(), permute(unthunk(Δtdst), invp; copy = true), NoTangent()
+        return NoTangent(), permute(unthunk(Δtdst), invp; copy = true, kwargs...), NoTangent()
     end
-    return permute(tsrc, p; copy = true), permute_pullback
+    return permute(tsrc, p; copy = true, kwargs...), permute_pullback
 end
 
 function ChainRulesCore.rrule(
-        ::typeof(transpose), tsrc::AbstractTensorMap, p::Index2Tuple; copy::Bool = false
+        ::typeof(transpose), tsrc::AbstractTensorMap, p::Index2Tuple; copy::Bool = false, kwargs...
     )
     function transpose_pullback(Δtdst)
         invp = TensorKit._canonicalize(TupleTools.invperm(linearize(p)), tsrc)
-        Δtsrc = transpose(unthunk(Δtdst), invp; copy = true)
+        Δtsrc = transpose(unthunk(Δtdst), invp; copy = true, kwargs...)
         return NoTangent(), ProjectTo(tsrc)(Δtsrc), NoTangent()
     end
-    return transpose(tsrc, p; copy = true), transpose_pullback
+    return transpose(tsrc, p; copy = true, kwargs...), transpose_pullback
 end
 
 function ChainRulesCore.rrule(::typeof(tr), A::AbstractTensorMap)

--- a/test/chainrules/linalg.jl
+++ b/test/chainrules/linalg.jl
@@ -15,6 +15,20 @@ using MatrixAlgebraKit
 
 ChainRulesTestUtils.test_method_tables()
 
+# Not every partition of every space admits a `repartition`: for categories such as
+# `IsingBimodule ⊠ Irrep[A₄]` some cuts leave no valid fusion channel, and TensorKit signals
+# this with an `ArgumentError`. Only that is treated as "skip"; anything else propagates, so
+# a genuine regression cannot be silently swallowed by this guard.
+function isvalid_repartition(t, k)
+    try
+        repartition(t, k)
+    catch e
+        e isa ArgumentError && return false
+        rethrow()
+    end
+    return true
+end
+
 spacelist = ad_spacelist(fast_tests)
 
 for V in spacelist
@@ -112,6 +126,31 @@ for V in spacelist
 
             test_rrule(transpose, A, ((2, 5, 4), (1, 3)))
             symmetricbraiding && test_rrule(permute, A, ((1, 3, 2), (5, 4)))
+
+            # the rrules must accept every keyword the primal accepts: `repartition`
+            # forwards its own `backend`/`allocator` defaults on to `transpose`, so a
+            # `copy`-only rrule signature breaks AD for callers that pass no keywords at all
+            bakwargs = (;
+                backend = TensorOperations.DefaultBackend(),
+                allocator = TensorOperations.DefaultAllocator(),
+            )
+            test_rrule(transpose, A, ((2, 5, 4), (1, 3)); fkwargs = bakwargs)
+            symmetricbraiding &&
+                test_rrule(permute, A, ((1, 3, 2), (5, 4)); fkwargs = bakwargs)
+
+            # `repartition` has no rrule of its own: it is differentiated by AD-ing through
+            # its body down to the `transpose` rrule, so it has to be tested end-to-end
+            # rather than with `test_rrule`
+            ks = filter(k -> isvalid_repartition(A, k), 0:numind(A))
+            for k in ks
+                test_ad_rrule(repartition, A, k)
+            end
+            if !isempty(ks)
+                k = last(ks)
+                test_ad_rrule(repartition, A, k, numind(A) - k)
+                test_ad_rrule(repartition, A, k; fkwargs = (; copy = true))
+            end
+
             hasbraiding && test_rrule(twist, A, 1)
             hasbraiding && test_rrule(twist, A, [1, 3])
 

--- a/test/chainrules/linalg.jl
+++ b/test/chainrules/linalg.jl
@@ -15,20 +15,6 @@ using MatrixAlgebraKit
 
 ChainRulesTestUtils.test_method_tables()
 
-# Not every partition of every space admits a `repartition`: for categories such as
-# `IsingBimodule ⊠ Irrep[A₄]` some cuts leave no valid fusion channel, and TensorKit signals
-# this with an `ArgumentError`. Only that is treated as "skip"; anything else propagates, so
-# a genuine regression cannot be silently swallowed by this guard.
-function isvalid_repartition(t, k)
-    try
-        repartition(t, k)
-    catch e
-        e isa ArgumentError && return false
-        rethrow()
-    end
-    return true
-end
-
 spacelist = ad_spacelist(fast_tests)
 
 for V in spacelist
@@ -141,15 +127,12 @@ for V in spacelist
             # `repartition` has no rrule of its own: it is differentiated by AD-ing through
             # its body down to the `transpose` rrule, so it has to be tested end-to-end
             # rather than with `test_rrule`
-            ks = filter(k -> isvalid_repartition(A, k), 0:numind(A))
-            for k in ks
+            for k in 0:numind(A)
                 test_ad_rrule(repartition, A, k)
             end
-            if !isempty(ks)
-                k = last(ks)
-                test_ad_rrule(repartition, A, k, numind(A) - k)
-                test_ad_rrule(repartition, A, k; fkwargs = (; copy = true))
-            end
+            # also cover the explicit-`N₂` arity and the `copy` keyword
+            test_ad_rrule(repartition, A, 2, numind(A) - 2)
+            test_ad_rrule(repartition, A, 2; fkwargs = (; copy = true))
 
             hasbraiding && test_rrule(twist, A, 1)
             hasbraiding && test_rrule(twist, A, [1, 3])


### PR DESCRIPTION
Passes through the `backend` and `allocator` kwargs in the `rrule`s for `permute` and `transpose`.

While trying to clean up some old code I bumped into the fact that `repartition` was not differentiable using Zygote.jl, even though `transpose` recently got ChainRules support.

For example, running
```
sing TensorKit, LinearAlgebra, Zygote

V1 = Z2Space(0 => 2, 1 => 2)
V2 = Z2Space(0 => 1, 1 => 3)
V3 = Z2Space(0 => 2, 1 => 1)
t = randn(ComplexF64, V1 ⊗ V2 ← V3)

f(x) = norm(repartition(x, 1))^2

@show f(t)                       # primal works fine
Zygote.gradient(f, t)            # this throws
```
gives
```
f(t) = 29.547196264927052
ERROR: MethodError: no method matching rrule(::typeof(transpose), ::TensorMap{...}, ::Tuple{Tuple{Int64}, Tuple{Int64, Int64}}; copy::Bool, backend::TensorOperations.DefaultBackend, allocator::TensorOperations.DefaultAllocator)
This method does not support all of the given keyword arguments (and may not support any).
Closest candidates are:
  rrule(::typeof(transpose), ::AbstractTensorMap, ::Tuple{NTuple{N₁, Int64}, NTuple{N₂, Int64}} where {N₁, N₂}; copy) got unsupported keyword arguments "backend", "allocator"
   @ TensorKitChainRulesCoreExt ~/git/TensorKit.jl/ext/TensorKitChainRulesCoreExt/linalg.jl:72
```

It turns out that the `repartition` fills in default kwargs before forwarding to `transpose`, but the `transpose` `rrule` only accepts the `copy` keyword without support for the `backend` and `allocator` kwargs. The same was true for `permute`, and both are fixed and tested for here.