### PR TITLE
Fix: have table of contents render the tensors contents correctly

### DIFF
--- a/docs/make.jl
+++ b/docs/make.jl
@@ -20,6 +20,11 @@ links = InterLinks(
     "TensorKitSectors" => "https://quantumkithub.github.io/TensorKitSectors.jl/dev/"
 )
 
+TENSOR_PAGES = [
+    "man/tensors.md", "man/linearalgebra.md", "man/indexmanipulations.md",
+    "man/factorizations.md", "man/contractions.md", "man/precompilation.md",
+]
+
 pages = [
     "Home" => "index.md",
     "Manual" => [
@@ -27,14 +32,7 @@ pages = [
         "man/spaces.md", "man/symmetries.md",
         "man/sectors.md", "man/gradedspaces.md",
         "man/fusiontrees.md",
-        "Tensors" => [
-            "man/tensors.md",
-            "man/linearalgebra.md",
-            "man/indexmanipulations.md",
-            "man/factorizations.md",
-            "man/contractions.md",
-            "man/precompilation.md",
-        ],
+        "Tensors" => TENSOR_PAGES,
     ],
     "Library" => [
         "lib/sectors.md", "lib/fusiontrees.md",

--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -24,7 +24,7 @@ Support for storing and manipulating tensors on Nvidia and AMD GPUs is currently
 ## Contents of the manual
 
 ```@contents
-Pages = ["man/intro.md", "man/spaces.md", "man/symmetries.md", "man/sectors.md", "man/gradedspaces.md", "man/fusiontrees.md", "man/tensors.md", "man/tensormanipulations.md"]
+Pages = ["man/intro.md", "man/spaces.md", "man/symmetries.md", "man/sectors.md", "man/gradedspaces.md", "man/fusiontrees.md", Main.TENSOR_PAGES...]
 Depth = 2
 ```
 


### PR DESCRIPTION
The contents of the manual block was rendering the tensors section incorrectly due to a stale list of pages. I updated it in such a way that there can't be a drift anymore, following what's shown [here](https://documenter.juliadocs.org/stable/man/syntax/#@contents-block).