### PR TITLE
Fix contraction of tensors with mixed elementary space types

### DIFF
--- a/src/spaces/homspace.jl
+++ b/src/spaces/homspace.jl
@@ -321,6 +321,15 @@ function _contractedspace(
     return cod ← dom
 end
 
+# generic fallback for mixed elementary space type: compose the intermediate spaces
+function _contractedspace(
+        A::HomSpace, (oindA, cindA)::Index2Tuple,
+        B::HomSpace, (cindB, oindB)::Index2Tuple,
+        pAB::Index2Tuple
+    )
+    return permute(compose(select(A, (oindA, cindA)), select(B, (cindB, oindB))), pAB)
+end
+
 function TensorOperations.tensorcontract(
         A::HomSpace, pA::Index2Tuple, conjA::Bool,
         B::HomSpace, pB::Index2Tuple, conjB::Bool,


### PR DESCRIPTION
#515 replaced `permute(compose(permute(A, pA), permute(B, pB)), pAB)` with a helper whose signature pins both hom-spaces to one elementary space type `S`. This breaks contractions of tensors with mixed elementary space types, for example when contracting a `BlockTensorMap` with a `TensorMap` (observed when trying to run MPSKit.jl off the current TensorKit.jl main).

For example:

```julia
using TensorKit, BlockTensorKit, TensorOperations

V = Vect[FermionParity ⊠ U1Irrep]((0, 0) => 2, (1, 1) => 2, (1, -1) => 2)
Vsum = SumSpace(V, V)

GL = rand(ComplexF64, Vsum ⊗ Vsum ← SumSpace(V))   # BlockTensorMap, (2, 1)
A  = rand(ComplexF64, V ← V ⊗ V)                   # plain TensorMap,  (1, 2)

@tensor y[-1 -2; -3 -4] := GL[-1 -2; 1] * A[1; -3 -4]
```
results in
```
MethodError: no method matching _contractedspace(::TensorMapSpace{SumSpace{…}, 2, 1}, …, ::TensorMapSpace{GradedSpace{…}, 1, 2}, …)
```

This adds a generic fallback for `_contractedspace` which composes the intermediate spaces.